### PR TITLE
WIP: Adding a first stab at a variable-length-delimited codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,31 @@ repository = "https://github.com/boltlabs-inc/dialectic"
 keywords = ["session", "types", "async", "channel", "protocol"]
 
 [features]
-default = ["mpsc"]
+default = ["mpsc", "serialize"]
 mpsc = ["tokio"]
+serialize = ["futures", "tokio", "tokio-util", "tokio-serde", "serde", "bytes"]
 
 [dependencies]
-async-trait = "0.1"
 thiserror = "1"
 call-by = "0.1"
 tokio = { version = "0.3", features = ["sync"], optional = true }
+tokio-util = { version = "0.5", features = ["codec"], optional = true }
+tokio-serde = { version = "0.7", optional = true }
+bincode-crate = { package = "bincode", version = "1.3", optional = true }
+serde = { version = "1", optional = true }
+bytes = { version = "0.6", optional = true }
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.3", features = ["full"] }
 static_assertions = "1.1"
+tokio-util = { version = "0.5", features = ["codec"] }
+tokio-serde = { version = "0.7" }
+bincode-crate = { package = "bincode", version = "1.3" }
+serde = { version = "1" }
+bytes = { version = "0.6" }
+futures = { version = "0.3" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,30 +9,31 @@ repository = "https://github.com/boltlabs-inc/dialectic"
 keywords = ["session", "types", "async", "channel", "protocol"]
 
 [features]
-default = ["mpsc", "serialize"]
-mpsc = ["tokio"]
-serialize = ["futures", "tokio", "tokio-util", "tokio-serde", "serde", "bytes"]
+default = ["mpsc", "serde"]
+mpsc = ["tokio/sync"]
+serde = ["futures", "tokio/io-util", "tokio-util/codec", "serde-crate"]
+bincode = ["serde", "bincode-crate", "bytes"]
+json = ["serde", "serde_json"]
 
 [dependencies]
 thiserror = "1"
 call-by = "0.1"
-tokio = { version = "0.3", features = ["sync"], optional = true }
-tokio-util = { version = "0.5", features = ["codec"], optional = true }
-tokio-serde = { version = "0.7", optional = true }
+tokio = { version = "1", optional = true }
+tokio-util = { version = "0.6", optional = true }
 bincode-crate = { package = "bincode", version = "1.3", optional = true }
-serde = { version = "1", optional = true }
-bytes = { version = "0.6", optional = true }
+serde_json = { version = "1", optional = true }
+serde-crate = { package = "serde", version = "1", optional = true }
 futures = { version = "0.3", optional = true }
+bytes = { version = "1", optional = true }
 
 [dev-dependencies]
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 static_assertions = "1.1"
-tokio-util = { version = "0.5", features = ["codec"] }
-tokio-serde = { version = "0.7" }
 bincode-crate = { package = "bincode", version = "1.3" }
-serde = { version = "1" }
-bytes = { version = "0.6" }
-futures = { version = "0.3" }
+serde_json = "1"
+serde-crate = { package = "serde", version = "1" }
+futures = "0.3"
+bytes = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -12,11 +12,11 @@ pub use call_by::*;
 use std::{future::Future, pin::Pin};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "mpsc")))]
-#[cfg(any(test, feature = "mpsc"))]
+#[cfg(feature = "mpsc")]
 pub mod mpsc;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "serialize")))]
-#[cfg(any(test, feature = "serialize"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+#[cfg(feature = "serde")]
 pub mod serde;
 
 /// If something is `Transmit<'a, T, Convention>`, we can use it to [`Transmit::send`] a message of

--- a/src/backend/serde.rs
+++ b/src/backend/serde.rs
@@ -1,0 +1,233 @@
+use std::{future::Future, pin::Pin};
+
+use crate::backend::{Receive, Ref, Transmit, Val};
+use bytes::{Bytes, BytesMut};
+use futures::sink::SinkExt;
+use futures::stream::StreamExt;
+use std::fmt::{Debug, Display};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_serde::{Deserializer, Serializer};
+use tokio_util::codec::{Decoder, Encoder, FramedRead, FramedWrite};
+
+pub fn symmetrical<F, E, W, R>(
+    format: F,
+    encoding: E,
+    writer: W,
+    reader: R,
+) -> (Sender<F, E, W>, Receiver<F, E, R>)
+where
+    F: Clone,
+    E: Decoder + Clone,
+    W: AsyncWrite,
+    R: AsyncRead,
+{
+    (
+        Sender::new(format.clone(), encoding.clone(), writer),
+        Receiver::new(format, encoding, reader),
+    )
+}
+
+#[derive(Debug)]
+pub struct Sender<F, E, W> {
+    serializer: F,
+    framed_write: FramedWrite<W, E>,
+}
+
+impl<F, E, W: AsyncWrite> Sender<F, E, W> {
+    pub fn new(serializer: F, encoder: E, writer: W) -> Self {
+        Sender {
+            serializer,
+            framed_write: FramedWrite::new(writer, encoder),
+        }
+    }
+}
+
+impl<'a, T: Sync + 'a, F, E, W> Transmit<'a, T, Ref> for Sender<F, E, W>
+where
+    F: Serializer<T> + Unpin + Send,
+    F::Error: Send,
+    E: Encoder<Bytes> + Send,
+    W: AsyncWrite + Unpin + Send,
+{
+    type Error = SendError<T, F, E>;
+
+    fn send<'async_lifetime>(
+        &'async_lifetime mut self,
+        message: &'a T,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
+    where
+        'a: 'async_lifetime,
+    {
+        Box::pin(async move {
+            let serialized = Pin::new(&mut self.serializer)
+                .serialize(message)
+                .map_err(SendError::Serialize)?;
+            self.framed_write
+                .send(serialized)
+                .await
+                .map_err(SendError::Encode)?;
+            Ok(())
+        })
+    }
+}
+
+impl<'a, T: 'a, F, E, W> Transmit<'a, T, Val> for Sender<F, E, W>
+where
+    T: Send,
+    F: Serializer<T> + Unpin + Send,
+    E: Encoder<Bytes> + Send,
+    W: AsyncWrite + Unpin + Send,
+{
+    type Error = SendError<T, F, E>;
+
+    fn send<'async_lifetime>(
+        &'async_lifetime mut self,
+        message: T,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
+    where
+        'a: 'async_lifetime,
+    {
+        Box::pin(async move {
+            let serialized = Pin::new(&mut self.serializer)
+                .serialize(&message)
+                .map_err(SendError::Serialize)?;
+            self.framed_write
+                .send(serialized)
+                .await
+                .map_err(SendError::Encode)?;
+            Ok(())
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct Receiver<F, D, R> {
+    deserializer: F,
+    framed_read: FramedRead<R, D>,
+}
+
+impl<F, D: Decoder, R: AsyncRead> Receiver<F, D, R> {
+    pub fn new(deserializer: F, decoder: D, reader: R) -> Self {
+        Receiver {
+            deserializer,
+            framed_read: FramedRead::new(reader, decoder),
+        }
+    }
+
+    pub fn with_capacity(deserializer: F, decoder: D, reader: R, capacity: usize) -> Self {
+        Receiver {
+            deserializer,
+            framed_read: FramedRead::with_capacity(reader, decoder, capacity),
+        }
+    }
+}
+
+impl<T, F, D, R> Receive<T> for Receiver<F, D, R>
+where
+    F: Deserializer<T> + Unpin + Send,
+    D: Decoder<Item = BytesMut> + Send,
+    R: AsyncRead + Unpin + Send,
+{
+    type Error = RecvError<T, F, D>;
+
+    fn recv<'async_lifetime>(
+        &'async_lifetime mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<T, Self::Error>> + Send + 'async_lifetime>> {
+        Box::pin(async move {
+            let unframed = self
+                .framed_read
+                .next()
+                .await
+                .ok_or(RecvError::Closed)?
+                .map_err(RecvError::Decode)?;
+            Ok(Pin::new(&mut self.deserializer)
+                .deserialize(&unframed)
+                .map_err(RecvError::Deserialize)?)
+        })
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SendError<T, F: Serializer<T>, E: Encoder<Bytes>> {
+    Serialize(F::Error),
+    Encode(E::Error),
+}
+
+impl<T, F: Serializer<T>, E: Encoder<Bytes>> Debug for SendError<T, F, E>
+where
+    F::Error: Debug,
+    E::Error: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            SendError::Serialize(err) => write!(f, "{:?}", err),
+            SendError::Encode(err) => write!(f, "{:?}", err),
+        }
+    }
+}
+
+impl<T, F: Serializer<T>, E: Encoder<Bytes>> Display for SendError<T, F, E>
+where
+    F::Error: Display,
+    E::Error: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            SendError::Serialize(err) => write!(f, "{}", err),
+            SendError::Encode(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl<T, F, E> std::error::Error for SendError<T, F, E>
+where
+    F: Serializer<T>,
+    E: Encoder<Bytes>,
+    F::Error: Display + Debug,
+    E::Error: Display + Debug,
+{
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RecvError<T, F: Deserializer<T>, D: Decoder> {
+    Deserialize(F::Error),
+    Decode(D::Error),
+    Closed,
+}
+
+impl<T, F: Deserializer<T>, D: Decoder> Debug for RecvError<T, F, D>
+where
+    F::Error: Debug,
+    D::Error: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RecvError::Deserialize(err) => write!(f, "{:?}", err),
+            RecvError::Decode(err) => write!(f, "{:?}", err),
+            RecvError::Closed => write!(f, "Closed"),
+        }
+    }
+}
+
+impl<T, F: Deserializer<T>, D: Decoder> Display for RecvError<T, F, D>
+where
+    F::Error: Display,
+    D::Error: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RecvError::Deserialize(err) => write!(f, "{}", err),
+            RecvError::Decode(err) => write!(f, "{}", err),
+            RecvError::Closed => write!(f, "connection closed"),
+        }
+    }
+}
+
+impl<T, F, D> std::error::Error for RecvError<T, F, D>
+where
+    F: Deserializer<T>,
+    D: Decoder,
+    F::Error: Display + Debug,
+    D::Error: Display + Debug,
+{
+}

--- a/src/backend/serde.rs
+++ b/src/backend/serde.rs
@@ -18,6 +18,8 @@ mod json;
 #[cfg(feature = "json")]
 pub use json::*;
 
+pub mod var_length_delimited;
+
 /// The serialization end of a serialization format: an object which can serialize any [`Serialize`]
 /// value.
 pub trait Serializer {

--- a/src/backend/serde/bincode.rs
+++ b/src/backend/serde/bincode.rs
@@ -1,0 +1,33 @@
+use super::*;
+use bincode_crate as bincode;
+use bytes::Bytes;
+use serde_crate::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Bincode<O: bincode::Options>(O);
+
+impl<O: bincode::Options> From<O> for Bincode<O> {
+    fn from(o: O) -> Self {
+        Bincode(o)
+    }
+}
+
+impl<O: bincode::Options + Clone> Serializer for Bincode<O> {
+    type Error = bincode::Error;
+    type Output = Bytes;
+
+    fn serialize<T: Serialize>(&mut self, item: &T) -> Result<Self::Output, Self::Error> {
+        self.0.clone().serialize(item).map(Into::into)
+    }
+}
+
+impl<O: bincode::Options + Clone, Input> Deserializer<Input> for Bincode<O>
+where
+    Input: AsRef<[u8]>,
+{
+    type Error = bincode::Error;
+
+    fn deserialize<T: for<'a> Deserialize<'a>>(&mut self, src: &Input) -> Result<T, Self::Error> {
+        self.0.clone().deserialize(src.as_ref())
+    }
+}

--- a/src/backend/serde/json.rs
+++ b/src/backend/serde/json.rs
@@ -1,0 +1,38 @@
+use super::*;
+use serde_json as json;
+use tokio_util::codec::LinesCodec;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Json {
+    _private: (),
+}
+
+impl Serializer for Json {
+    type Error = json::Error;
+    type Output = String;
+
+    fn serialize<T: Serialize>(&mut self, item: &T) -> Result<Self::Output, Self::Error> {
+        json::to_string(item)
+    }
+}
+
+impl<Input: AsRef<str>> Deserializer<Input> for Json {
+    type Error = json::Error;
+
+    fn deserialize<T: for<'a> Deserialize<'a>>(&mut self, src: &Input) -> Result<T, Self::Error> {
+        json::from_str(src.as_ref())
+    }
+}
+
+pub fn json_lines<W: AsyncWrite, R: AsyncRead>(
+    writer: W,
+    reader: R,
+    max_length: usize,
+) -> (Sender<Json, LinesCodec, W>, Receiver<Json, LinesCodec, R>) {
+    symmetrical(
+        Json::default(),
+        LinesCodec::new_with_max_length(max_length),
+        writer,
+        reader,
+    )
+}

--- a/src/backend/serde/var_length_delimited.rs
+++ b/src/backend/serde/var_length_delimited.rs
@@ -1,0 +1,194 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use std::convert::TryInto;
+use std::io::{self, Cursor};
+use tokio_util::codec::{Decoder, Encoder};
+
+#[derive(Debug)]
+pub struct VarLengthDelimitedCodec {
+    builder: Builder,
+    state: DecodeState,
+}
+
+impl VarLengthDelimitedCodec {
+    pub fn new(max_frame_length: usize) -> Self {
+        VarLengthDelimitedCodec {
+            builder: Builder { max_frame_length },
+            state: DecodeState::Init,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Builder {
+    max_frame_length: usize,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum DecodeState {
+    Init,
+    FirstLengthByte {
+        length: u8,
+    },
+    RestOfLength {
+        length: u64,
+        remaining_length_bytes: u8,
+    },
+    Data {
+        length: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct VarLengthDelimitedCodecError {
+    _private: (),
+}
+
+impl Decoder for VarLengthDelimitedCodec {
+    type Item = BytesMut;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> io::Result<Option<BytesMut>> {
+        use DecodeState::*;
+
+        // The decoder is a state machine that stops (with saved state) every time it reaches the
+        // end of the buffer, and resets to the initial state when it finally extracts the data it's
+        // looking for. The only exit from this loop is the one where we hit `Data { length }` and
+        // return the contained length, which means we've read the entire header and we're now ready
+        // to process data, if it's there.
+        let length = loop {
+            self.state = match self.state {
+                // Read the first byte
+                //
+                // Layout:
+                //
+                // - [0][7 bits of a small numeric value, to be immediately returned], or
+                // - [1][0][6 bits of a small length, to be immediately processed], or
+                // - [1][1][the first 6 bits of the length]
+                Init if src.has_remaining() => {
+                    let b0 = src.get_u8(); // First byte of frame
+                    if (b0 & 0b_1_0000000) == 0 {
+                        // Value was < 128, so returned directly: 0 bytes framing overhead
+                        return Ok(Some(BytesMut::from(vec![b0].as_slice())));
+                    } else if (b0 & 0b_01_000000) == 0 {
+                        // Length fits in 6 bits: 1 byte framing overhead
+                        let length = (b0 & 0b_00_111111) as u64;
+                        Data { length }
+                    } else {
+                        // Length is longer than 6 bits, so we need to read at least one more
+                        src.reserve(1usize.saturating_sub(src.remaining()));
+                        FirstLengthByte {
+                            length: b0 & 0b_00_111111,
+                        }
+                    }
+                }
+
+                // Read the second byte of the length
+                //
+                // Layout: [2 bits indicating how many more length bytes][6 bits of length]
+                FirstLengthByte { length } if src.has_remaining() => {
+                    let b1 = src.get_u8(); // Second byte of frame
+
+                    // The high 2 bits indicate how many more length bytes (after this one) we need
+                    let remaining_length_bytes = b1 >> 6;
+
+                    // The updated length is the catenation of the old length and the low 6 bits of
+                    // the byte we just read
+                    let length = ((length as u64) << 6) & ((b1 & 0b_00_111111) as u64);
+
+                    if remaining_length_bytes == 0 {
+                        // Length fits in 6 + 6 bits (i.e. < 2^12 = 4096): 2 bytes framing overhead
+                        Data { length }
+                    } else {
+                        // We need to read more length bytes (1, 2, or 3 are the possible amounts)
+                        src.reserve(
+                            (remaining_length_bytes as usize).saturating_sub(src.remaining()),
+                        );
+                        RestOfLength {
+                            length: length as u64,
+                            remaining_length_bytes,
+                        }
+                    }
+                }
+
+                // Read the rest of the length bytes (there may be up to 3)
+                //
+                // Layout: [8 bits of length] * remaining_length_bytes
+                RestOfLength {
+                    mut length,
+                    remaining_length_bytes,
+                } if src.remaining() >= remaining_length_bytes as usize => {
+                    // Collect the up-to-3 bytes
+                    for _ in 1..=remaining_length_bytes {
+                        length = (length << 8) & (src.get_u8() as u64);
+                    }
+                    let length = length as u64;
+                    Data { length }
+                }
+
+                // If we already know the length, immediately proceed to reading the data
+                Data { length } => break length,
+
+                // Waiting for more bytes before we continue
+                _ => return Ok(None),
+            }
+        };
+
+        // Check for overflow of maximum frame size (which must be <= usize::MAX)
+        if length > self.builder.max_frame_length as u64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "provided length would overflow maximum frame size",
+            ));
+        }
+
+        // This can't truncate because of the check above
+        let length = length as usize;
+
+        // Reserve enough space for the data to be read
+        src.reserve(length.saturating_sub(src.remaining()));
+
+        if src.remaining() < length {
+            // We can't return the full frame yet because we don't have enough data
+            Ok(None)
+        } else {
+            // Reset the decode state
+            self.state = Init;
+
+            // Reserve at least one byte for the next head (we don't know how long it will be!)
+            src.reserve(1);
+
+            // Return the data, dropping it off `src`
+            Ok(Some(src.split_to(length)))
+        }
+    }
+}
+
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::io::AsyncWriteExt;
+    use tokio_util::codec::FramedRead;
+
+    #[test]
+    fn decode_works() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let header = vec![0b10_000010];
+        let data = vec![255, 255];
+        let expected = data.clone();
+        rt.block_on(async {
+            let (mut s1, mut s2) = tokio::io::duplex(64);
+            let t1 = tokio::spawn(async move {
+                s1.write_all(&header).await.unwrap();
+                s1.write_all(&data).await.unwrap();
+            });
+            let t2 = tokio::spawn(async move {
+                let mut fr2 = FramedRead::new(s2, VarLengthDelimitedCodec::new(10000));
+                let v = fr2.next().await.unwrap().unwrap();
+                assert_eq!(v, BytesMut::from(expected.as_slice()));
+            });
+            t1.await.unwrap();
+            t2.await.unwrap();
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! > **dialectic (noun):** The process of arriving at the truth by stating a thesis, developing a
 //! > contradictory antithesis, and combining them into a coherent synthesis.
 //! >
-//! > **dialectic (crate):** Zero-cost session types for asynchronous Rust.
+//! > **dialectic (crate):** Transport-polymorphic session types for asynchronous Rust.
 //!
 //! When two concurrent processes communicate, it's good to give their messages *types*, which
 //! ensure every message is of an expected form.
@@ -15,7 +15,7 @@
 //! compile-time guarantees that a specified *session protocol* will not be violated by any code
 //! using the channel. Such a wrapped channel:
 //!
-//! - has **zero runtime cost** in time or memory;
+//! - has **almost no runtime cost** in time or memory;
 //! - is **built on `async`/`.await`** to allow integration with Rust's powerful `async` ecosystem;
 //! - gracefully handles runtime protocol violations, introducing **no panics**; and
 //! - allows for **full duplex concurrent communication**, if specified in its type, while

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,7 @@
 
 #![recursion_limit = "256"]
 #![allow(clippy::type_complexity)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use std::{
     marker::{self, PhantomData},
     sync::Arc,


### PR DESCRIPTION
This means discriminants will have zero framing overhead. However, it's
quite tricky to get right, and for a first demo, I think it's best to
put this aside.