### PR TITLE
Modular control: add `Break`, make `Done` default to `Continue` when inside `Loop`

### DIFF
--- a/examples/tally/client.rs
+++ b/examples/tally/client.rs
@@ -1,93 +1,116 @@
-use dialectic::backend::serde::format::length_delimited_bincode;
+use std::fmt::Display;
+
+use dialectic::backend::serde::{
+    format::{length_delimited_bincode, Bincode},
+    SymmetricalError,
+};
 use dialectic::constants::*;
 use dialectic::*;
 
-use tokio::io::{self, AsyncBufReadExt, BufReader};
+use tokio::io::{self, AsyncBufRead, AsyncBufReadExt, BufReader, Lines};
 use tokio::net::TcpStream;
 
 mod server;
-use server::{get_port, Operation, Server};
+use server::{get_port, wrap_socket, BincodeTcpChan, Operation, Server};
+use tokio_util::codec::LengthDelimitedCodec;
 
 // The client is the dual of the server
 type Client = <Server as Session>::Dual;
+
+/// Loop presenting a prompt until the user enters a parseable string or the input ends, returning
+/// `Ok(None)` on end of input and `Err(_)` on other errors.
+async fn parse_line_loop<T, E, R>(
+    prompt: &str,
+    lines: &mut Lines<R>,
+    mut parse: impl FnMut(&str) -> Result<T, E>,
+) -> io::Result<Option<T>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    loop {
+        eprint!("{}", prompt);
+        match lines.next_line().await? {
+            Some(line) => match parse(line.trim()) {
+                Ok(t) => break Ok(Some(t)),
+                Err(_) => continue,
+            },
+            None => break Ok(None),
+        }
+    }
+}
+
+/// Parse a string as a yes-or-no response
+fn yes_or_no(s: &str) -> Result<bool, ()> {
+    match s.to_uppercase().as_ref() {
+        "Y" | "YES" => Ok(true),
+        "N" | "NO" => Ok(false),
+        _ => Err(()),
+    }
+}
+
+fn number_or_tally(s: &str) -> Result<Option<i64>, ()> {
+    let s = s.trim();
+    if s == "" {
+        Ok(None)
+    } else if let Ok(n) = s.parse() {
+        Ok(Some(n))
+    } else {
+        Err(())
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Connect to the server and assemble into a transport using length-delimited bincode
     let port = get_port()?;
-    let mut connection = TcpStream::connect(("127.0.0.1", port)).await?;
-    let (rx, tx) = connection.split();
-    let (tx, rx) = length_delimited_bincode(tx, rx, 3, 8 * 1024);
+    let connection = TcpStream::connect(("127.0.0.1", port)).await?;
+    interact(wrap_socket::<Client>(connection, 8 * 1024)).await?;
+    Ok(())
+}
 
+async fn interact(
+    mut chan_outer: BincodeTcpChan<Client>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Hook up stdin as a stream of lines, and stdout as a writer
     let mut stdin = BufReader::new(io::stdin()).lines();
 
-    // Now let's use session types!
-    let mut chan_outer = Client::wrap(tx, rx);
-    let chan_outer = 'outer: loop {
+    'outer: loop {
         // Get the desired operation from the user
-        let operation = loop {
-            eprint!("Operation (+/*): ");
-            match stdin.next_line().await? {
-                Some(l) if l.trim() == "+" => break Operation::Sum,
-                Some(l) if l.trim() == "*" => break Operation::Product,
-                Some(_) => continue,
-                None => {
-                    // If the user ends the input stream here, before selecting an operation, there
-                    // is no possible way (aside from inventing an operation from thin air) to
-                    // continue to follow the protocol and make it to the end. We choose to
-                    // ungracefully end the program immediately, triggering an error on the server
-                    // side.
-                    std::process::exit(1)
-                }
-            };
-        };
+        let operation = parse_line_loop("Operation (+ / *): ", &mut stdin, str::parse)
+            .await?
+            .unwrap_or_else(|| std::process::exit(1));
 
         // Send the desired operation
         let mut chan_inner = chan_outer.send(&operation).await?;
 
-        eprintln!("Input numbers to tally (tally with `=`):");
+        eprintln!("Input numbers to tally (newline to tally):");
         chan_outer = 'inner: loop {
-            let n = loop {
-                let line = stdin.next_line().await?;
-                if let Some(line) = line {
-                    if line == "=" {
-                        // User wants to get the final tally
-                        let (tally, chan_inner) = chan_inner.choose(_1).await?.recv().await?;
-                        println!("{}", tally);
-                        loop {
-                            // Ask whether to do another tally, and jump to the right place
-                            eprintln!("Another tally? (Y/n)");
-                            match stdin.next_line().await?.map(|s| s.to_uppercase()) {
-                                Some(l) if l == "Y" || l == "YES" => {
-                                    break 'inner chan_inner.choose(_1).await?
-                                }
-                                Some(l) if l == "N" || l == "NO" => {
-                                    break 'outer chan_inner.choose(_0).await?
-                                }
-                                None => break 'outer chan_inner.choose(_0).await?,
-                                _ => continue,
-                            }
-                        }
-                    } else {
-                        // User wants to submit another number to the tally
-                        match line.parse() {
-                            Ok(n) => break n,
-                            Err(err) => eprintln!("Parse error: {}", err),
-                        }
+            match parse_line_loop(&format!("{} ", operation), &mut stdin, number_or_tally).await? {
+                Some(Some(n)) => {
+                    // Choose to repeat the inner loop, and repeat
+                    chan_inner = chan_inner.choose(_0).await?.send(&n).await?;
+                }
+                Some(None) => {
+                    // User wants to get the final tally
+                    let (tally, chan_inner) = chan_inner.choose(_1).await?.recv().await?;
+                    println!("= {}", tally);
+                    match parse_line_loop("Another tally? (Y/n): ", &mut stdin, yes_or_no)
+                        .await?
+                        .unwrap_or(false)
+                    {
+                        true => break 'inner chan_inner.choose(_1).await?,
+                        false => break 'outer chan_inner.choose(_0).await?,
                     }
-                } else {
+                }
+                None => {
                     // End of input stream, so let's cleanly finish up with the server
                     let (tally, chan_inner) = chan_inner.choose(_1).await?.recv().await?;
-                    eprintln!("=");
-                    println!("{}", tally);
+                    println!("= {}", tally);
                     break 'outer chan_inner.choose(_0).await?;
                 }
             };
-            // Choose to repeat the inner loop, and repeat
-            chan_inner = chan_inner.choose(_0).await?.send(&n).await?;
         };
-    };
-    chan_outer.close();
+    }
+    .close();
     Ok(())
 }

--- a/examples/tally/server.rs
+++ b/examples/tally/server.rs
@@ -1,15 +1,28 @@
 #![allow(unused)]
-use dialectic::backend::serde::format::{length_delimited_bincode, Bincode};
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+use thiserror::Error;
+
+use dialectic::backend::serde::{
+    format::{length_delimited_bincode, Bincode},
+    Receiver, Sender, SymmetricalError,
+};
 use dialectic::constants::*;
 use dialectic::unary::types::*;
 use dialectic::*;
 
 use serde_crate::{Deserialize, Serialize};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::{
+    tcp::ReadHalf,
+    tcp::{OwnedReadHalf, OwnedWriteHalf, WriteHalf},
+    TcpListener, TcpStream,
+};
 use tokio_util::codec::LengthDelimitedCodec;
 
 pub type Server =
-    Loop<Recv<Operation, Loop<Offer<(Recv<i64, Recur>, Send<i64, Offer<(End, Recur<_1>)>>)>>>>;
+    Loop<Recv<Operation, Loop<Offer<(Recv<i64>, Send<i64, Offer<(Break<_1>, Break)>>)>>>>;
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")] // we only need this because we renamed serde in Cargo.toml
@@ -19,19 +32,70 @@ pub enum Operation {
 }
 
 impl Operation {
-    fn unit(&self) -> i64 {
+    pub fn unit(&self) -> i64 {
         match self {
             Operation::Sum => 0,
             Operation::Product => 1,
         }
     }
 
-    fn combine(&self, x: i64, y: i64) -> i64 {
+    pub fn combine(&self, x: i64, y: i64) -> i64 {
         match self {
             Operation::Sum => x + y,
             Operation::Product => x * y,
         }
     }
+}
+
+#[derive(Debug, Copy, Clone, Error)]
+#[error("couldn't parse operation")]
+pub struct ParseOperationError;
+
+impl FromStr for Operation {
+    type Err = ParseOperationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "+" => Ok(Operation::Sum),
+            "*" => Ok(Operation::Product),
+            _ => Err(ParseOperationError),
+        }
+    }
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Operation::Sum => write!(f, "+"),
+            Operation::Product => write!(f, "*"),
+        }
+    }
+}
+
+// TODO: generalize this into the library to make a normalized Chan type synonym so things work out
+// nicely instead of weirdly clashing because of auto-ff-ing through loops and recurs?
+#[allow(type_alias_bounds)]
+pub type BincodeTcpChan<P, E = ()>
+where
+    P: Actionable<E>,
+    E: Environment,
+= Chan<
+    Sender<Bincode, LengthDelimitedCodec, OwnedWriteHalf>,
+    Receiver<Bincode, LengthDelimitedCodec, OwnedReadHalf>,
+    P::Action,
+    P::Env,
+>;
+
+pub fn wrap_socket<'a, P>(mut socket: TcpStream, max_length: usize) -> BincodeTcpChan<P>
+where
+    P: NewSession,
+    P::Dual: Actionable<()>,
+    <P::Env as EachSession>::Dual: Environment,
+    <<P::Dual as Actionable<()>>::Env as EachSession>::Dual: Environment,
+{
+    let (rx, tx) = socket.into_split();
+    let (tx, rx) = length_delimited_bincode(tx, rx, 4, max_length);
+    P::wrap(tx, rx)
 }
 
 /// Try to parse a port number as the first argument to the program, returning a descriptive error
@@ -60,7 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (mut socket, addr) = listener.accept().await?;
         eprintln!("Accepted: {}", addr);
         tokio::spawn(async move {
-            serve(socket)
+            serve(wrap_socket::<Server>(socket, 8 * 1024))
                 .await
                 .map(|_| eprintln!("Finished: {}", addr))
                 .map_err(|err| eprintln!("Error on: {}: {}", addr, err))
@@ -69,16 +133,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn serve(
-    mut socket: TcpStream,
-) -> Result<(), backend::serde::Error<Bincode, Bincode, LengthDelimitedCodec, LengthDelimitedCodec>>
-{
-    // Assemble a length-delimited bincode transport...
-    let (rx, tx) = socket.split();
-    let (tx, rx) = length_delimited_bincode(tx, rx, 3, 8 * 1024);
-
-    // Now let's use session types!
-    let mut chan_outer = Server::wrap(tx, rx);
-    let chan_outer = 'outer: loop {
+    mut chan_outer: BincodeTcpChan<Server>,
+) -> Result<(), SymmetricalError<Bincode, LengthDelimitedCodec>> {
+    'outer: loop {
         // What operation should we use?
         let (op, mut chan_inner) = chan_outer.recv().await?;
 
@@ -106,9 +163,7 @@ async fn serve(
                 }
             });
         };
-    };
-
-    // Prove to the type system that we completed the protocol
-    chan_outer.close();
+    }
+    .close();
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,10 +202,10 @@ where
 /// recursion.
 pub trait NewSession
 where
-    Self: Actionable<()>,
-    Self::Dual: Actionable<()>,
+    Self: Actionable,
+    Self::Dual: Actionable,
     <Self::Env as EachSession>::Dual: Environment,
-    <<Self::Dual as Actionable<()>>::Env as EachSession>::Dual: Environment,
+    <<Self::Dual as Actionable>::Env as EachSession>::Dual: Environment,
 {
     /// Given a closure which generates a uni-directional underlying transport channel, create a
     /// pair of dual [`Chan`]s which communicate over the transport channels resulting from these
@@ -228,7 +228,7 @@ where
         make: impl FnMut() -> (Tx, Rx),
     ) -> (
         Chan<Tx, Rx, Self::Action, Self::Env>,
-        Chan<Tx, Rx, <Self::Dual as Actionable<()>>::Action, <Self::Dual as Actionable<()>>::Env>,
+        Chan<Tx, Rx, <Self::Dual as Actionable>::Action, <Self::Dual as Actionable>::Env>,
     );
 
     /// Given two closures, each of which generates a uni-directional underlying transport channel,
@@ -256,7 +256,7 @@ where
         make1: impl FnOnce() -> (Tx1, Rx1),
     ) -> (
         Chan<Tx0, Rx1, Self::Action, Self::Env>,
-        Chan<Tx1, Rx0, <Self::Dual as Actionable<()>>::Action, <Self::Dual as Actionable<()>>::Env>,
+        Chan<Tx1, Rx0, <Self::Dual as Actionable>::Action, <Self::Dual as Actionable>::Env>,
     );
 
     /// Given a transmitting and receiving end of an un-session-typed connection, wrap them in a new
@@ -290,16 +290,16 @@ where
 
 impl<P> NewSession for P
 where
-    Self: Actionable<()>,
-    Self::Dual: Actionable<()>,
+    Self: Actionable,
+    Self::Dual: Actionable,
     <Self::Env as EachSession>::Dual: Environment,
-    <<Self::Dual as Actionable<()>>::Env as EachSession>::Dual: Environment,
+    <<Self::Dual as Actionable>::Env as EachSession>::Dual: Environment,
 {
     fn channel<Tx, Rx>(
         mut make: impl FnMut() -> (Tx, Rx),
     ) -> (
         Chan<Tx, Rx, Self::Action, Self::Env>,
-        Chan<Tx, Rx, <Self::Dual as Actionable<()>>::Action, <Self::Dual as Actionable<()>>::Env>,
+        Chan<Tx, Rx, <Self::Dual as Actionable>::Action, <Self::Dual as Actionable>::Env>,
     ) {
         let (tx0, rx0) = make();
         let (tx1, rx1) = make();
@@ -311,7 +311,7 @@ where
         make1: impl FnOnce() -> (Tx1, Rx1),
     ) -> (
         Chan<Tx0, Rx1, Self::Action, Self::Env>,
-        Chan<Tx1, Rx0, <Self::Dual as Actionable<()>>::Action, <Self::Dual as Actionable<()>>::Env>,
+        Chan<Tx1, Rx0, <Self::Dual as Actionable>::Action, <Self::Dual as Actionable>::Env>,
     ) {
         let (tx0, rx0) = make0();
         let (tx1, rx1) = make1();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ where
 
 impl<Tx, Rx, P, E> Chan<Tx, Rx, P, E>
 where
-    P: Actionable<E, Action = Done>,
+    P: Actionable<E, Action = Done, Env = ()>,
     E: Environment,
     E::Dual: Environment,
     <P::Env as EachSession>::Dual: Environment,

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -13,12 +13,12 @@
 //! ```
 //! use dialectic::*;
 //!
-//! type JustSendOneString = Send<String, End>;
+//! type JustSendOneString = Send<String, Done>;
 //! ```
 //!
 //! This type specifies a very simple protocol: "send a string, then finish." The first argument to
 //! `Send` is the type sent, and the second is the rest of the protocol, which in this case is the
-//! empty protocol [`End`].
+//! empty protocol [`Done`].
 //!
 //! Every session type has a [`Dual`](crate::Session::Dual), which describes what the other end of
 //! the channel must do to follow the channel's protocol; if one end [`Send`]s, the other end must
@@ -27,17 +27,17 @@
 //! ```
 //! # use dialectic::*;
 //! # use static_assertions::assert_type_eq_all;
-//! assert_type_eq_all!(<Send<String, End> as Session>::Dual, Recv<String, End>);
+//! assert_type_eq_all!(<Send<String, Done> as Session>::Dual, Recv<String, Done>);
 //! ```
 //!
 //! Because many sessions end with either a `Send` or a `Recv`, their types can be abbreviated when
-//! the rest of the session is `End`:
+//! the rest of the session is `Done`:
 //!
 //! ```
 //! # use dialectic::*;
 //! # use static_assertions::assert_type_eq_all;
-//! assert_type_eq_all!(Send<String>, Send<String, End>);
-//! assert_type_eq_all!(Recv<String>, Recv<String, End>);
+//! assert_type_eq_all!(Send<String>, Send<String, Done>);
+//! assert_type_eq_all!(Recv<String>, Recv<String, Done>);
 //! ```
 //!
 //! Given a valid session type, we can wrap an underlying communications channel with it. Here,
@@ -61,7 +61,7 @@
 //! ```
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
 //! ```
 //!
@@ -71,7 +71,7 @@
 //! ```
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! # let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
 //! let _: Chan<mpsc::Sender, mpsc::Receiver, Send<String>> = c1;
 //! let _: Chan<mpsc::Sender, mpsc::Receiver, Recv<String>> = c2;
@@ -85,7 +85,7 @@
 //! ```
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
@@ -121,7 +121,7 @@
 //! ```
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! type ParityOfLength = Send<String, Recv<usize, Send<bool>>>;
@@ -176,7 +176,7 @@
 //!
 //! ```
 //! # use dialectic::*;
-//! type JustSendOneString = Send<String, End>;
+//! type JustSendOneString = Send<String, Done>;
 //! ```
 //!
 //! Trying to do any of the below things results in a compile-time type error (edited for brevity).
@@ -186,7 +186,7 @@
 //! ```compile_fail
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
@@ -206,7 +206,7 @@
 //! ```compile_fail
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
@@ -231,7 +231,7 @@
 //! ```compile_fail
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
@@ -241,11 +241,11 @@
 //! # }
 //! ```
 //!
-//! ...we get an error we saying the returned channel is now of type `Chan<_, _, End>`, and we can't
-//! send when it's the end:
+//! ...we get an error we saying the returned channel is now of type `Chan<_, _, Done>`, and we
+//! can't send when it's the end:
 //!
 //! ```text
-//! error[E0599]: no method named `send` found for struct `Chan<Sender, Receiver, End>` in the current scope
+//! error[E0599]: no method named `send` found for struct `Chan<Sender, Receiver, Done>` in the current scope
 //! ```
 //!
 //! # Branching out
@@ -276,13 +276,13 @@
 //!
 //! Suppose we want to offer a choice between two protocols: either sending a single integer
 //! (`Send<i64>`) or receiving a string (`Recv<String>`). Correspondingly, the other end of the
-//! channel must indicate a choice of which protocol to follow, and we need to handle the result
-//! of either selection by enacting the protocol chosen.
+//! channel must indicate a choice of which protocol to follow, and we need to handle the result of
+//! either selection by enacting the protocol chosen.
 //!
 //! ```
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type JustSendOneString = Send<String, End>;
+//! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use dialectic::constants::*;
@@ -318,7 +318,7 @@
 //! may use that channel. In each expression, the channel's type corresponds to the session type for
 //! that choice. The type of each expression in the list must be the same, which means that if we
 //! want to bind a channel name to the result of the `offer!`, each expression must step the channel
-//! forward to an identical session type (in the case above, that's `End`).
+//! forward to an identical session type (in the case above, that's `Done`).
 //!
 //! Dually, to select an offered option, you can call the [`choose`](Chan::choose) method on a
 //! channel, passing it as input a constant corresponding to the index of the choice. These
@@ -425,10 +425,10 @@
 //! the corresponding `Loop` is valid for that `Chan`.
 //!
 //! This behavior is enabled by the [`Actionable`] trait, which defines what the next "real action"
-//! on a session type is. For [`End`], [`Send`], [`Recv`], [`Offer`], [`Choose`], and [`Split`] (the
-//! final session type discussed below), the "real action" is that session type itself. However, for
-//! [`Loop`] and [`Recur`], the next action is whatever follows entering the loop(s) or recurring,
-//! respectively.
+//! on a session type is. For [`Done`], [`Send`], [`Recv`], [`Offer`], [`Choose`], and [`Split`]
+//! (the final session type discussed below), the "real action" is that session type itself.
+//! However, for [`Loop`] and [`Recur`], the next action is whatever follows entering the loop(s) or
+//! recurring, respectively.
 //!
 //! In most uses of Dialectic, you won't need to directly care about the [`Actionable`] trait or
 //! most of the traits in [`types`] aside from [`Session`]. It's good to know what it's for, though,

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -343,8 +343,8 @@
 //! type QuerySum = Loop<Choose<(Send<i64, Continue>, Recv<i64>)>>;
 //! ```
 //!
-//! The dual to `Loop<P>` is `Loop<P::Dual>`, and the dual to `Continue` is `Continue`, so we know the
-//! other end of this channel will need to implement:
+//! The dual to `Loop<P>` is `Loop<P::Dual>`, and the dual to `Continue` is `Continue`, so we know
+//! the other end of this channel will need to implement:
 //!
 //! ```
 //! # use dialectic::*;
@@ -408,10 +408,10 @@
 //! ## Nested loops
 //!
 //! If the protocol contains nested loops, you can specify which nested loop to continue with  using
-//! the optional parameter of `Continue`. By default, `Continue` jumps to the innermost loop; however,
-//! `Continue<_1>` jumps to the second-innermost, `Continue<_2>` the third-innermost, etc. The types
-//! [`_0`](unary::types::_0), [`_1`](unary::types::_1), [`_2`](unary::types::_2), etc. are defined
-//! in the [`unary::types`] module.
+//! the optional parameter of `Continue`. By default, `Continue` jumps to the innermost loop;
+//! however, `Continue<_1>` jumps to the second-innermost, `Continue<_2>` the third-innermost, etc.
+//! The types [`_0`](unary::types::_0), [`_1`](unary::types::_1), [`_2`](unary::types::_2), etc. are
+//! defined in the [`unary::types`] module.
 //!
 //! ## Automatic looping
 //!
@@ -421,14 +421,14 @@
 //! [`Continue`]s to a session type for which a given operation is valid, that operation is valid on
 //! the [`Chan`]. In the instance above, calling [`choose`](Chan::choose) on a [`Chan`] with session
 //! type `Loop<Choose<...>>` works, no matter how many `Loop`s enclose the `Choose`. Similarly, if a
-//! `Chan`'s type is `Continue`, whatever operation would be valid for the session type at the start of
-//! the corresponding `Loop` is valid for that `Chan`.
+//! `Chan`'s type is `Continue`, whatever operation would be valid for the session type at the start
+//! of the corresponding `Loop` is valid for that `Chan`.
 //!
 //! This behavior is enabled by the [`Actionable`] trait, which defines what the next "real action"
 //! on a session type is. For [`Done`], [`Send`], [`Recv`], [`Offer`], [`Choose`], and [`Split`]
 //! (the final session type discussed below), the "real action" is that session type itself.
-//! However, for [`Loop`] and [`Continue`], the next action is whatever follows entering the loop(s) or
-//! recurring, respectively.
+//! However, for [`Loop`] and [`Continue`], the next action is whatever follows entering the loop(s)
+//! or recurring, respectively.
 //!
 //! In most uses of Dialectic, you won't need to directly care about the [`Actionable`] trait or
 //! most of the traits in [`types`] aside from [`Session`]. It's good to know what it's for, though,

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -336,35 +336,35 @@
 //! these can be modeled with session types by introducing *recursion*.
 //!
 //! Suppose we want to send a stream of as many integers as desired, then receive back their sum. We
-//! could describe this protocol using the [`Loop`] and [`Recur`] types:
+//! could describe this protocol using the [`Loop`] and [`Continue`] types:
 //!
 //! ```
 //! # use dialectic::*;
-//! type QuerySum = Loop<Choose<(Send<i64, Recur>, Recv<i64>)>>;
+//! type QuerySum = Loop<Choose<(Send<i64, Continue>, Recv<i64>)>>;
 //! ```
 //!
-//! The dual to `Loop<P>` is `Loop<P::Dual>`, and the dual to `Recur` is `Recur`, so we know the
+//! The dual to `Loop<P>` is `Loop<P::Dual>`, and the dual to `Continue` is `Continue`, so we know the
 //! other end of this channel will need to implement:
 //!
 //! ```
 //! # use dialectic::*;
 //! # use static_assertions::assert_type_eq_all;
-//! # type QuerySum = Loop<Choose<(Send<i64, Recur>, Recv<i64>)>>;
-//! type ComputeSum = Loop<Offer<(Recv<i64, Recur>, Send<i64>)>>;
+//! # type QuerySum = Loop<Choose<(Send<i64, Continue>, Recv<i64>)>>;
+//! type ComputeSum = Loop<Offer<(Recv<i64, Continue>, Send<i64>)>>;
 //! assert_type_eq_all!(<QuerySum as Session>::Dual, ComputeSum);
 //! ```
 //!
 //! We can implement this protocol by following the session types. When the session type of a
-//! [`Chan`] hits a [`Recur`] point, it jumps back to the type of the [`Loop`] to which that
-//! [`Recur`] refers. In this case, for example, immediately after the querying task sends an
-//! integer, the resultant channel will have the session type `Choose<(Send<i64, Recur>,
+//! [`Chan`] hits a [`Continue`] point, it jumps back to the type of the [`Loop`] to which that
+//! [`Continue`] refers. In this case, for example, immediately after the querying task sends an
+//! integer, the resultant channel will have the session type `Choose<(Send<i64, Continue>,
 //! Recv<i64>)>` once more.
 //!
 //! ```
 //! # use dialectic::*;
 //! # use dialectic::backend::mpsc;
-//! # type QuerySum = Loop<Choose<(Send<i64, Recur>, Recv<i64>)>>;
-//! # type ComputeSum = Loop<Offer<(Recv<i64, Recur>, Send<i64>)>>;
+//! # type QuerySum = Loop<Choose<(Send<i64, Continue>, Recv<i64>)>>;
+//! # type ComputeSum = Loop<Offer<(Recv<i64, Continue>, Send<i64>)>>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # use dialectic::constants::*;
@@ -408,8 +408,8 @@
 //! ## Nested loops
 //!
 //! If the protocol contains nested loops, you can specify which nested loop to continue with  using
-//! the optional parameter of `Recur`. By default, `Recur` jumps to the innermost loop; however,
-//! `Recur<_1>` jumps to the second-innermost, `Recur<_2>` the third-innermost, etc. The types
+//! the optional parameter of `Continue`. By default, `Continue` jumps to the innermost loop; however,
+//! `Continue<_1>` jumps to the second-innermost, `Continue<_2>` the third-innermost, etc. The types
 //! [`_0`](unary::types::_0), [`_1`](unary::types::_1), [`_2`](unary::types::_2), etc. are defined
 //! in the [`unary::types`] module.
 //!
@@ -418,16 +418,16 @@
 //! You may have noticed how in the example above, [`choose`](Chan::choose) can be called on `c1`
 //! even though the outermost part of `c1`'s session type `QuerySum` would seem not to begin with
 //! [`Choose`]. This is true in general: if the session type of a [`Chan`] either [`Loop`]s or
-//! [`Recur`]s to a session type for which a given operation is valid, that operation is valid on
+//! [`Continue`]s to a session type for which a given operation is valid, that operation is valid on
 //! the [`Chan`]. In the instance above, calling [`choose`](Chan::choose) on a [`Chan`] with session
 //! type `Loop<Choose<...>>` works, no matter how many `Loop`s enclose the `Choose`. Similarly, if a
-//! `Chan`'s type is `Recur`, whatever operation would be valid for the session type at the start of
+//! `Chan`'s type is `Continue`, whatever operation would be valid for the session type at the start of
 //! the corresponding `Loop` is valid for that `Chan`.
 //!
 //! This behavior is enabled by the [`Actionable`] trait, which defines what the next "real action"
 //! on a session type is. For [`Done`], [`Send`], [`Recv`], [`Offer`], [`Choose`], and [`Split`]
 //! (the final session type discussed below), the "real action" is that session type itself.
-//! However, for [`Loop`] and [`Recur`], the next action is whatever follows entering the loop(s) or
+//! However, for [`Loop`] and [`Continue`], the next action is whatever follows entering the loop(s) or
 //! recurring, respectively.
 //!
 //! In most uses of Dialectic, you won't need to directly care about the [`Actionable`] trait or

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
 //! The types in this module enumerate the shapes of all expressible sessions.
 
 use super::*;
-pub use unary::*;
+pub use unary::types::*;
+pub use unary::{constants, LessThan, Unary, S, Z};
 
 pub mod tuple;
 pub mod unary;
@@ -202,6 +203,7 @@ where
     type Selected = <(P, Rest) as Select<N>>::Selected;
     type Remainder = <(P, Rest) as Select<N>>::Remainder;
 }
+
 mod sealed {
     use super::*;
 
@@ -221,6 +223,7 @@ mod sealed {
 
 /// Asserts that the specified type is a valid *closed* session type (that is, it does not
 /// `Continue` outside itself).
+#[cfg(test)]
 #[macro_export]
 macro_rules! assert_all_closed_sessions {
     () => {};

--- a/src/types.rs
+++ b/src/types.rs
@@ -203,36 +203,6 @@ where
     type Remainder = <(P, Rest) as Select<N>>::Remainder;
 }
 
-/// Select by index from a type level list, returning a default value if the index is out of bounds.
-///
-/// This is used internally by the [`Break`] session type.
-pub trait SelectDefault<N: Unary, Default>: sealed::SelectDefault<N, Default> {
-    /// The thing which is selected from this list by the index `N`, or the default value if the
-    /// index is out of bounds.
-    type Selected;
-
-    /// The remainder of the list after the selected thing, or `()` if the index is out of bounds.
-    type Remainder;
-}
-
-impl<N: Unary, Default> SelectDefault<N, Default> for () {
-    type Selected = Default;
-    type Remainder = ();
-}
-
-impl<Default, T, Rest> SelectDefault<Z, Default> for (T, Rest) {
-    type Selected = T;
-    type Remainder = Rest;
-}
-
-impl<N: Unary, Default, T, Rest> SelectDefault<S<N>, Default> for (T, Rest)
-where
-    Rest: SelectDefault<N, Default>,
-{
-    type Selected = Rest::Selected;
-    type Remainder = Rest::Remainder;
-}
-
 mod sealed {
     use super::*;
 
@@ -248,14 +218,6 @@ mod sealed {
     pub trait Select<N: Unary> {}
     impl<T, S> Select<Z> for (T, S) {}
     impl<T, P, Rest, N: Unary> Select<S<N>> for (T, (P, Rest)) where (P, Rest): Select<N> {}
-
-    pub trait SelectDefault<N: Unary, Default> {}
-    impl<N: Unary, Default> SelectDefault<N, Default> for () {}
-    impl<Default, T, Rest> SelectDefault<Z, Default> for (T, Rest) {}
-    impl<N: Unary, Default, T, Rest> SelectDefault<S<N>, Default> for (T, Rest) where
-        Rest: SelectDefault<N, Default>
-    {
-    }
 }
 
 mod test {

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,8 +22,8 @@ pub mod unary;
 /// # use static_assertions::assert_type_eq_all;
 /// use dialectic::types::*;
 ///
-/// type Client = Loop<Offer<(Split<Send<String, End>, Recv<usize, End>>, Recv<bool, Recur>)>>;
-/// type Server = Loop<Choose<(Split<Send<usize, End>, Recv<String, End>>, Send<bool, Recur>)>>;
+/// type Client = Loop<Offer<(Split<Send<String, Done>, Recv<usize, Done>>, Recv<bool, Recur>)>>;
+/// type Server = Loop<Choose<(Split<Send<usize, Done>, Recv<String, Done>>, Send<bool, Recur>)>>;
 ///
 /// assert_type_eq_all!(Client, <Server as Session>::Dual);
 /// ```
@@ -156,7 +156,7 @@ where
 impl<N: Unary, P: Scoped<N>, Q: Scoped<N>> Scoped<N> for Split<P, Q> {}
 impl<N: Unary, P: Scoped<S<N>>> Scoped<N> for Loop<P> {}
 impl<N: Unary, M: Unary> Scoped<M> for Recur<N> where N: LessThan<M> {}
-impl<N: Unary> Scoped<N> for End {}
+impl<N: Unary> Scoped<N> for Done {}
 
 /// In the [`Choose`] and [`Offer`] session types, `EachScoped<N>` is used to assert that every
 /// choice or offering is well-[`Scoped`].
@@ -199,20 +199,20 @@ where
     type Remainder = <(P, Rest) as Select<N>>::Remainder;
 }
 
-/// Complete a session. The only thing to do with a [`Chan`] at its `End` is to drop it.
+/// Complete a session. The only thing to do with a [`Chan`] at its `Done` is to drop it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct End;
+pub struct Done;
 
-impl Session for End {
-    type Dual = End;
+impl Session for Done {
+    type Dual = Done;
 }
 
-impl<E> Actionable<E> for End
+impl<E> Actionable<E> for Done
 where
     E: Environment,
     E::Dual: Environment,
 {
-    type Action = End;
+    type Action = Done;
     type Env = E;
 }
 
@@ -221,10 +221,10 @@ where
 /// # Notes
 ///
 /// A session ending with a `Recv` can be abbreviated: `Recv<String>` is shorthand for `Recv<String,
-/// End>`.
+/// Done>`.
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Recv<T, P = End>(pub PhantomData<T>, pub P);
+pub struct Recv<T, P = Done>(pub PhantomData<T>, pub P);
 
 impl<T, P: Session> Session for Recv<T, P> {
     type Dual = Send<T, P::Dual>;
@@ -245,10 +245,10 @@ where
 /// # Notes
 ///
 /// A session ending with a `Send` can be abbreviated: `Send<String>` is shorthand for `Send<String,
-/// End>`.
+/// Done>`.
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Send<T, P = End>(pub PhantomData<T>, pub P);
+pub struct Send<T, P = Done>(pub PhantomData<T>, pub P);
 
 impl<T, P: Session> Session for Send<T, P> {
     type Dual = Recv<T, P::Dual>;
@@ -406,7 +406,7 @@ mod sealed {
     use super::*;
 
     pub trait IsSession {}
-    impl IsSession for End {}
+    impl IsSession for Done {}
     impl<T, P> IsSession for Recv<T, P> {}
     impl<T, P> IsSession for Send<T, P> {}
     impl<Choices> IsSession for Choose<Choices> {}

--- a/src/types/break.rs
+++ b/src/types/break.rs
@@ -1,0 +1,62 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Break out of a [`Loop`]. The type-level index points to the loop to be broken, counted from the
+/// innermost starting at [`Z`].
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Break<N: Unary = Z>(pub N);
+
+impl<N: Unary> IsSession for Break<N> {}
+
+impl<N: Unary> Session for Break<N> {
+    type Dual = Break<N>;
+}
+
+impl<N: Unary, M: Unary> Scoped<M> for Break<N> where N: LessThan<M> {}
+
+/// Break from the outermost loop: end the session.
+impl<P> Actionable<(P, ())> for Break<Z>
+where
+    (P, ()): Environment,
+    <(P, ()) as EachSession>::Dual: Environment,
+    Z: LessThan<<(P, ()) as Environment>::Depth>, // this is always true but Rust doesn't know it
+{
+    type Action = Done;
+    type Env = ();
+}
+
+/// Break from a non-outermost loop: continue whatever loop we broke into.
+impl<P, Q, Rest> Actionable<(P, (Q, Rest))> for Break<Z>
+where
+    Q: Actionable<(Q, Rest)>,
+    Q: Scoped<S<<Rest as Environment>::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
+    P: Scoped<S<S<<Rest as Environment>::Depth>>>
+        + Scoped<S<S<<Rest::Dual as Environment>::Depth>>>,
+    P::Dual: Scoped<S<S<<Rest as Environment>::Depth>>>
+        + Scoped<S<S<<Rest::Dual as Environment>::Depth>>>,
+    Q::Dual:
+        Scoped<S<<Rest as Environment>::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
+    Q::Env: Environment,
+    Rest: Environment,
+    Rest::Dual: Environment,
+    <Q::Env as EachSession>::Dual: Environment,
+{
+    type Action = Q::Action;
+    type Env = Q::Env;
+}
+
+/// Inductive case: break one less level from one less loop.
+impl<N: Unary, P, Rest> Actionable<(P, Rest)> for Break<S<N>>
+where
+    N: LessThan<Rest::Depth>,
+    Break<N>: Actionable<Rest>,
+    P: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
+    P::Dual: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
+    Rest: Environment,
+    Rest::Dual: Environment,
+    <<Break<N> as Actionable<Rest>>::Env as EachSession>::Dual: Environment,
+{
+    type Action = <Break<N> as Actionable<Rest>>::Action;
+    type Env = <Break<N> as Actionable<Rest>>::Env;
+}

--- a/src/types/break.rs
+++ b/src/types/break.rs
@@ -67,7 +67,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::unary::types::*;
     use super::*;
     use crate::assert_all_closed_sessions;
 

--- a/src/types/choose.rs
+++ b/src/types/choose.rs
@@ -1,0 +1,41 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Actively choose using [`Chan::choose`] between any of the protocols in the tuple `Choices`.
+///
+/// At most 128 choices can be presented to a `Choose` type; to choose from more options, nest
+/// `Choose`s within each other.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Choose<Choices>(pub Choices);
+
+impl<Choices> IsSession for Choose<Choices> {}
+
+impl<Choices> Session for Choose<Choices>
+where
+    Choices: Tuple,
+    Choices::AsList: EachSession,
+    <Choices::AsList as EachSession>::Dual: List + EachSession,
+{
+    type Dual = Offer<<<Choices::AsList as EachSession>::Dual as List>::AsTuple>;
+}
+
+impl<N: Unary, Choices: Tuple> Scoped<N> for Choose<Choices>
+where
+    Choices::AsList: EachScoped<N>,
+    <Choices::AsList as EachSession>::Dual: List,
+{
+}
+
+impl<E, Choices> Actionable<E> for Choose<Choices>
+where
+    Choices: Tuple,
+    Choices::AsList: EachSession,
+    <Choices::AsList as EachSession>::Dual: List + EachSession,
+    Choices::AsList: EachScoped<E::Depth>,
+    E: Environment,
+    E::Dual: Environment,
+{
+    type Action = Choose<Choices>;
+    type Env = E;
+}

--- a/src/types/continue.rs
+++ b/src/types/continue.rs
@@ -1,0 +1,36 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Repeat a [`Loop`]. The type-level index points to the loop to be repeated, counted from the
+/// innermost starting at [`Z`].
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Continue<N: Unary = Z>(pub N);
+
+impl<N: Unary> IsSession for Continue<N> {}
+
+impl<N: Unary> Session for Continue<N> {
+    type Dual = Continue<N>;
+}
+
+impl<N: Unary, M: Unary> Scoped<M> for Continue<N> where N: LessThan<M> {}
+
+impl<E, N: Unary> Actionable<E> for Continue<N>
+where
+    E: Select<N> + Environment,
+    Continue<N>: Scoped<E::Depth>,
+    E::Selected: Actionable<(E::Selected, E::Remainder)>,
+    E::Selected: Scoped<S<<E::Remainder as Environment>::Depth>>,
+    <E::Selected as Session>::Dual: Scoped<S<<E::Remainder as Environment>::Depth>>,
+    E::Selected: Scoped<S<<<E::Remainder as EachSession>::Dual as Environment>::Depth>>,
+    <E::Selected as Session>::Dual:
+        Scoped<S<<<E::Remainder as EachSession>::Dual as Environment>::Depth>>,
+    E::Dual: Environment,
+    E::Remainder: Environment,
+    <E::Remainder as EachSession>::Dual: Environment,
+    <<E::Selected as Actionable<(E::Selected, E::Remainder)>>::Env as EachSession>::Dual:
+        Environment,
+{
+    type Action = <E::Selected as Actionable<(E::Selected, E::Remainder)>>::Action;
+    type Env = <E::Selected as Actionable<(E::Selected, E::Remainder)>>::Env;
+}

--- a/src/types/done.rs
+++ b/src/types/done.rs
@@ -1,0 +1,33 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Complete a session. The only thing to do with a [`Chan`] at its `Done` is to drop it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Done;
+
+impl IsSession for Done {}
+
+impl Session for Done {
+    type Dual = Done;
+}
+
+impl Actionable<()> for Done {
+    type Action = Done;
+    type Env = ();
+}
+
+impl<N: Unary> Scoped<N> for Done {}
+
+/// When inside a `Loop`, `Done` repeats the innermost loop.
+impl<P, Rest> Actionable<(P, Rest)> for Done
+where
+    Continue: Actionable<(P, Rest)>,
+    P: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
+    P::Dual: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
+    Rest: Environment,
+    Rest::Dual: Environment,
+    <<Continue as Actionable<(P, Rest)>>::Env as EachSession>::Dual: Environment,
+{
+    type Action = <Continue as Actionable<(P, Rest)>>::Action;
+    type Env = <Continue as Actionable<(P, Rest)>>::Env;
+}

--- a/src/types/loop.rs
+++ b/src/types/loop.rs
@@ -1,0 +1,30 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Label a loop point, which can be reiterated with [`Continue`], or implicitly with [`Done`].
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Loop<P>(pub P);
+
+impl<P> IsSession for Loop<P> {}
+
+impl<P: Session> Session for Loop<P> {
+    type Dual = Loop<P::Dual>;
+}
+
+impl<N: Unary, P: Scoped<S<N>>> Scoped<N> for Loop<P> {}
+
+impl<P, E> Actionable<E> for Loop<P>
+where
+    E: Environment,
+    E::Dual: Environment,
+    P: Actionable<(P, E)>,
+    P: Scoped<S<E::Depth>>,
+    P: Scoped<S<<E::Dual as Environment>::Depth>>,
+    P::Dual: Scoped<S<E::Depth>>,
+    P::Dual: Scoped<S<<E::Dual as Environment>::Depth>>,
+    <P::Env as EachSession>::Dual: Environment,
+{
+    type Action = <P as Actionable<(P, E)>>::Action;
+    type Env = <P as Actionable<(P, E)>>::Env;
+}

--- a/src/types/offer.rs
+++ b/src/types/offer.rs
@@ -1,0 +1,42 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Offer the choice using [`Chan::offer`] or the [`offer!`](crate::offer) macro between any of the
+/// protocols in the tuple `Choices`.
+///
+/// At most 128 choices can be offered in a single `Offer` type; to supply more options, nest
+/// `Offer`s within each other.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Offer<Choices>(pub Choices);
+
+impl<Choices> IsSession for Offer<Choices> {}
+
+impl<Choices> Session for Offer<Choices>
+where
+    Choices: Tuple,
+    Choices::AsList: EachSession,
+    <Choices::AsList as EachSession>::Dual: List + EachSession,
+{
+    type Dual = Choose<<<Choices::AsList as EachSession>::Dual as List>::AsTuple>;
+}
+
+impl<N: Unary, Choices: Tuple> Scoped<N> for Offer<Choices>
+where
+    Choices::AsList: EachScoped<N>,
+    <Choices::AsList as EachSession>::Dual: List,
+{
+}
+
+impl<E, Choices> Actionable<E> for Offer<Choices>
+where
+    Choices: Tuple,
+    Choices::AsList: EachSession,
+    <Choices::AsList as EachSession>::Dual: List + EachSession,
+    Choices::AsList: EachScoped<E::Depth>,
+    E: Environment,
+    E::Dual: Environment,
+{
+    type Action = Offer<Choices>;
+    type Env = E;
+}

--- a/src/types/recv.rs
+++ b/src/types/recv.rs
@@ -1,0 +1,30 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Receive a message of type `T` using [`Chan::recv`], then continue with protocol `P`.
+///
+/// # Notes
+///
+/// A session ending with a `Recv` can be abbreviated: `Recv<String>` is shorthand for `Recv<String,
+/// Done>`.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Recv<T, P = Done>(pub PhantomData<T>, pub P);
+
+impl<T, P> IsSession for Recv<T, P> {}
+
+impl<T, P: Session> Session for Recv<T, P> {
+    type Dual = Send<T, P::Dual>;
+}
+
+impl<N: Unary, T, P: Scoped<N>> Scoped<N> for Recv<T, P> {}
+
+impl<E, T, P> Actionable<E> for Recv<T, P>
+where
+    P: Scoped<E::Depth>,
+    E: Environment,
+    E::Dual: Environment,
+{
+    type Action = Recv<T, P>;
+    type Env = E;
+}

--- a/src/types/send.rs
+++ b/src/types/send.rs
@@ -1,0 +1,30 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Send a message of type `T` using [`Chan::send`], then continue with protocol `P`.
+///
+/// # Notes
+///
+/// A session ending with a `Send` can be abbreviated: `Send<String>` is shorthand for `Send<String,
+/// Done>`.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Send<T, P = Done>(pub PhantomData<T>, pub P);
+
+impl<T, P> IsSession for Send<T, P> {}
+
+impl<T, P: Session> Session for Send<T, P> {
+    type Dual = Recv<T, P::Dual>;
+}
+
+impl<N: Unary, T, P: Scoped<N>> Scoped<N> for Send<T, P> {}
+
+impl<E, T, P> Actionable<E> for Send<T, P>
+where
+    P: Scoped<E::Depth>,
+    E: Environment,
+    E::Dual: Environment,
+{
+    type Action = Send<T, P>;
+    type Env = E;
+}

--- a/src/types/split.rs
+++ b/src/types/split.rs
@@ -1,0 +1,29 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Split the connection into send-only and receive-only halves using [`Chan::split`]. These can
+/// subsequently be rejoined using [`Chan::unsplit`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Split<P, Q>(pub P, pub Q);
+
+impl<P, Q> IsSession for Split<P, Q> {}
+
+impl<P: Session, Q: Session> Session for Split<P, Q> {
+    /// Note how the dual flips the position of P and Q, because P::Dual is a receiving session, and
+    /// therefore belongs on the right of the split, and Q::Dual is a sending session, and therefore
+    /// belongs on the left of the split.
+    type Dual = Split<Q::Dual, P::Dual>;
+}
+
+impl<N: Unary, P: Scoped<N>, Q: Scoped<N>> Scoped<N> for Split<P, Q> {}
+
+impl<E, P, Q> Actionable<E> for Split<P, Q>
+where
+    P: Scoped<E::Depth>,
+    Q: Scoped<E::Depth>,
+    E: Environment,
+    E::Dual: Environment,
+{
+    type Action = Split<P, Q>;
+    type Env = E;
+}


### PR DESCRIPTION
This PR implements an approach to increase the modularity of specifications written in the language of session types. Previously, when you would write a session type expressing a simple straight-line session, there was no way to substitute it into a larger protocol containing loops without modifying the type itself to end with `Recur` instead of `End`. In this set of changes, `End` (now *`Done`*) is the empty session that steps to nothing when outside a `Loop`, but is equivalent to `Recur` (now *`Continue`*) when inside a `Loop`. Additionally, a new `Break` operator is introduced, with equivalent semantics to `break` in Rust. Now the trifecta of `loop`/`continue`/`break` are all represented faithfully, with control automatically returning to the head of a `Loop` just as it does in ordinary programming languages: implicitly, unless otherwise specified.