### PR TITLE
Context-free session types and greater modularity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ serde_json = { version = "1", optional = true }
 serde-crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 futures = { version = "0.3", optional = true }
 bytes = { version = "1", optional = true }
+derivative = "2.1"
+pin-project = "1"
+static_assertions = "1.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dialectic
 
-![License: MIT](https://img.shields.io/github/license/boltlabs-inc/dialectic)
+![license: MIT](https://img.shields.io/github/license/boltlabs-inc/dialectic)
 [![crates.io](https://img.shields.io/crates/v/dialectic)](https://crates.io/crates/dialectic)
 [![docs.rs documentation](https://docs.rs/dialectic/badge.svg)](https://docs.rs/dialectic)
 
@@ -24,6 +24,8 @@ using the channel. Such a wrapped channel:
 - gracefully handles runtime protocol violations, introducing **no panics**; and
 - allows for **full duplex concurrent communication**, if specified in its type, while
   preserving all the same session-type safety guarantees.
+- allows the expression of **context free sessions**, a more general form of session that than
+  most other session typing libraries.
 
 Together, these make Dialectic ideal for writing networked services that need to ensure **high
 levels of availability** and **complex protocol correctness properties** in the real world,

--- a/examples/tally/client.rs
+++ b/examples/tally/client.rs
@@ -1,7 +1,5 @@
 #![allow(unused)]
-use dialectic::backend::{Choice, Receive, Ref, Transmit, Val};
-use dialectic::constants::*;
-use dialectic::*;
+use dialectic::prelude::*;
 use tokio::io::{self, AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, Lines};
 use tokio::net::TcpStream;
 
@@ -83,6 +81,7 @@ where
             let (done, chan_inner) = chan_inner
                 .seq(|chan| tally::<_, _, _, _, _, Err>(&operation, input, output, chan))
                 .await?;
+            let chan_inner = chan_inner.unwrap();
             if done {
                 break chan_inner.choose(_1).await?;
             } else {

--- a/examples/tally/client.rs
+++ b/examples/tally/client.rs
@@ -107,8 +107,6 @@ async fn tally<Tx, Rx, E, R, W, Err>(
 ) -> Result<bool, Err>
 where
     E: Environment,
-    Done: Actionable<E, Action = Done, Env = ()>,
-    Break: Actionable<<ClientTally as Actionable<E>>::Env, Action = Done, Env = ()>,
     R: AsyncBufRead + Unpin,
     W: AsyncWrite + Unpin,
     Rx: Receive<i64> + std::marker::Send + 'static,

--- a/examples/tally/server.rs
+++ b/examples/tally/server.rs
@@ -22,7 +22,7 @@ use tokio_util::codec::LengthDelimitedCodec;
 
 // The server's API:
 pub type Server = Loop<Offer<(Recv<Operation, Tally<i64>>, Break)>>;
-pub type Tally<T> = Loop<Offer<(Recv<T>, Send<T, Break>)>>;
+pub type Tally<T> = Loop<Offer<(Recv<T, Continue>, Send<T, Break>)>>;
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")] // we only need this because we renamed serde in Cargo.toml
@@ -85,8 +85,6 @@ pub fn wrap_socket<'a, P>(socket: TcpStream, max_length: usize) -> BincodeTcpCha
 where
     P: NewSession,
     P::Dual: Actionable,
-    <P::Env as EachSession>::Dual: Environment,
-    <<P::Dual as Actionable>::Env as EachSession>::Dual: Environment,
 {
     let (rx, tx) = socket.into_split();
     let (tx, rx) = length_delimited_bincode(tx, rx, 4, max_length);
@@ -131,8 +129,6 @@ where
     P::Dual: Actionable,
     P::Env: Environment + std::marker::Send,
     P::Action: std::marker::Send,
-    <P::Env as EachSession>::Dual: Environment,
-    <<P::Dual as Actionable>::Env as EachSession>::Dual: Environment,
 {
     let listener = TcpListener::bind(("127.0.0.1", port)).await?;
     loop {

--- a/examples/tally/server.rs
+++ b/examples/tally/server.rs
@@ -5,13 +5,8 @@ use std::{
 };
 use thiserror::Error;
 
-use dialectic::backend::{
-    serde::format::{length_delimited_bincode, Bincode},
-    Choice, Receive, Ref, Transmit,
-};
-use dialectic::constants::*;
-use dialectic::unary::types::*;
-use dialectic::*;
+use dialectic::backend::serde::format::{length_delimited_bincode, Bincode};
+use dialectic::prelude::*;
 
 use serde_crate::{Deserialize, Serialize};
 use tokio::net::{
@@ -72,7 +67,7 @@ impl Display for Operation {
     }
 }
 
-pub type BincodeTcpChan<P, E = ()> = backend::serde::SymmetricalChan<
+pub type BincodeTcpChan<P, E = ()> = dialectic::backend::serde::SymmetricalChan<
     Bincode,
     LengthDelimitedCodec,
     OwnedWriteHalf,
@@ -156,7 +151,7 @@ where
             // Client wants to compute another tally
             _0 => {
                 let (op, chan) = chan.recv().await?;
-                chan.seq(|chan| tally::<_, _, _, Err>(&op, chan)).await?.1
+                chan.seq(|chan| tally::<_, _, _, Err>(&op, chan)).await?.1.unwrap()
             },
             // Client wants to quit
             _1 => break chan,

--- a/examples/tally/server.rs
+++ b/examples/tally/server.rs
@@ -16,8 +16,8 @@ use tokio::net::{
 use tokio_util::codec::LengthDelimitedCodec;
 
 // The server's API:
-pub type Server = Loop<Offer<(Recv<Operation, Seq<Tally>>, Break)>>;
-pub type Tally = Loop<Offer<(Recv<i64, Continue>, Send<i64, Break>)>>;
+pub type Server = Loop<Offer<(Recv<Operation, Seq<Tally, Continue>>, Break)>>;
+pub type Tally = Loop<Offer<(Recv<i64, Continue>, Send<i64, Done>)>>;
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")] // we only need this because we renamed serde in Cargo.toml
@@ -170,7 +170,6 @@ where
     Err: From<<Tx as Transmit<i64, Ref>>::Error>
         + From<<Rx as Receive<i64>>::Error>
         + From<<Rx as Receive<Choice<_2>>>::Error>,
-    Break: Actionable<<Tally as Actionable<E>>::Env, Action = Done, Env = ()>,
 {
     let mut tally = op.unit();
     loop {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -54,26 +54,6 @@ pub trait Transmit<T, Convention: CallingConvention> {
         'a: 'async_lifetime;
 }
 
-impl<T, C, Convention> Transmit<T, Convention> for &'_ mut C
-where
-    C: Transmit<T, Convention>,
-    Convention: CallingConvention,
-{
-    type Error = C::Error;
-
-    fn send<'a, 'async_lifetime>(
-        &'async_lifetime mut self,
-        message: <T as CallBy<'a, Convention>>::Type,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
-    where
-        T: CallBy<'a, Convention>,
-        <T as CallBy<'a, Convention>>::Type: Send,
-        'a: 'async_lifetime,
-    {
-        (**self).send(message)
-    }
-}
-
 /// If a transport is `Receive<T>`, we can use it to [`recv`](Receive::recv) a message of type `T`.
 ///
 /// In order to support the [`Chan::offer`](crate::CanonicalChan::offer) method, all backends must
@@ -92,14 +72,4 @@ pub trait Receive<T> {
     fn recv<'async_lifetime>(
         &'async_lifetime mut self,
     ) -> Pin<Box<dyn Future<Output = Result<T, Self::Error>> + Send + 'async_lifetime>>;
-}
-
-impl<T: 'static, C: Receive<T> + Send> Receive<T> for &'_ mut C {
-    type Error = C::Error;
-
-    fn recv<'async_lifetime>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<T, Self::Error>> + Send + 'async_lifetime>> {
-        (**self).recv()
-    }
 }

--- a/src/backend/mpsc.rs
+++ b/src/backend/mpsc.rs
@@ -8,6 +8,15 @@ use std::{any::Any, future::Future, pin::Pin};
 use thiserror::Error;
 use tokio::sync::mpsc;
 
+/// Shorthand for a [`Chan`](crate::Chan) using a bounded [`mpsc`](crate::backend::mpsc) [`Sender`]
+/// and [`Receiver`].
+pub type Chan<'a, P, E = ()> = crate::Chan<Sender<'a>, Receiver<'a>, P, E>;
+
+/// Shorthand for a [`Chan`](crate::Chan) using an unbounded [`mpsc`](crate::backend::mpsc)
+/// [`UnboundedSender`] and [`UnboundedReceiver`].
+pub type UnboundedChan<'a, P, E = ()> =
+    crate::Chan<UnboundedSender<'a>, UnboundedReceiver<'a>, P, E>;
+
 /// A bounded receiver for dynamically typed values. See [`tokio::sync::mpsc::Receiver`].
 pub type Receiver<'a> = mpsc::Receiver<Box<dyn Any + Send + 'a>>;
 

--- a/src/backend/mpsc.rs
+++ b/src/backend/mpsc.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 
 /// Shorthand for a [`Chan`](crate::Chan) using a bounded [`mpsc`](crate::backend::mpsc) [`Sender`]
 /// and [`Receiver`].
-pub type Chan<'a, P, E = ()> = crate::Chan<Sender<'a>, Receiver<'a>, P, E>;
+pub type Chan<P, E = ()> = crate::Chan<Sender<'static>, Receiver<'static>, P, E>;
 
 /// Shorthand for a [`Chan`](crate::Chan) using an unbounded [`mpsc`](crate::backend::mpsc)
 /// [`UnboundedSender`] and [`UnboundedReceiver`].

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -733,7 +733,7 @@ where
     ///     mut chan: mpsc::Chan<Stack<T>>,
     /// ) -> Pin<Box<dyn Future<Output = Result<(), mpsc::Error>> + marker::Send>>
     /// where
-    ///     T: marker::Send + Debug + 'static,
+    ///     T: marker::Send + 'static,
     /// {
     ///     Box::pin(async move {
     ///         loop {
@@ -759,7 +759,7 @@ where
     ///     mut iter: impl Iterator<Item = T> + marker::Send + 'static,
     /// ) -> Pin<Box<dyn Future<Output = Result<Vec<T>, mpsc::Error>> + marker::Send>>
     /// where
-    ///     T: marker::Send + Debug + 'static,
+    ///     T: marker::Send + 'static,
     /// {
     ///     Box::pin(async move {
     ///         if let Some(t) = iter.next() {

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -659,7 +659,7 @@ impl<'a, Tx, Rx, E, P, Q> CanonicalChan<Tx, Rx, Seq<P, Q>, E>
 where
     Tx: marker::Send + 'static,
     Rx: marker::Send + 'static,
-    P: Actionable<E::MakeDone>,
+    P: Actionable<E>,
     Q: Actionable<E>,
     E: Environment,
 {
@@ -713,14 +713,14 @@ where
         first: F,
     ) -> Result<(T, Result<Chan<Tx, Rx, Q, E>, SessionIncomplete<Tx, Rx>>), Err>
     where
-        F: FnOnce(Chan<Tx, Rx, P, E::MakeDone>) -> Fut,
+        F: FnOnce(Chan<Tx, Rx, P, E>) -> Fut,
         Fut: Future<Output = Result<T, Err>>,
     {
         let tx = self.tx.take().unwrap();
         let rx = self.rx.take().unwrap();
         let drop_tx = self.drop_tx.take().unwrap();
         let drop_rx = self.drop_rx.take().unwrap();
-        let (result, maybe_chan) = over::<P, E::MakeDone, _, _, _, _, _, _>(tx, rx, first).await?;
+        let (result, maybe_chan) = over::<P, E, _, _, _, _, _, _>(tx, rx, first).await?;
         Ok((
             result,
             maybe_chan.map(|(tx, rx)| CanonicalChan {

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -793,9 +793,9 @@ where
     /// ```
     ///
     /// For more on context-free session types, see "Context-Free Session Type Inference" by Luca
-    /// Padovani: <https://doi.org/10.1145/3229062>. Note that the [`seq`](CanonicalChan::seq)
-    /// operator is roughly equivalent to the `@=` operator from that paper, and the [`Seq`] type is
-    /// equivalent to the `;` type in that paper.
+    /// Padovani: <https://doi.org/10.1145/3229062>. When comparing with that paper, note that the
+    /// [`seq`](CanonicalChan::seq) operator is roughly equivalent to its `@=` operator, and the
+    /// [`Seq`] type is equivalent to `;`.
     pub async fn seq<T, Err, F, Fut>(
         mut self,
         first: F,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,6 @@ where
     Choices: Tuple,
     Choices::AsList: EachActionable<E>,
     E: Environment,
-    E::Dual: Environment,
 {
     variant: u8,
     tx: Tx,
@@ -226,11 +225,6 @@ where
     P: Actionable<E>,
     Ps: EachActionable<E> + List,
     E: Environment,
-    E::Dual: Environment,
-    P::Dual: Actionable<E::Dual>,
-    <P::Env as EachSession>::Dual: Environment,
-    <<P::Action as Actionable<P::Env>>::Env as EachSession>::Dual: Environment,
-    <<P::Dual as Actionable<E::Dual>>::Env as EachSession>::Dual: Environment,
 {
     /// Check if the selected protocol in this [`Branches`] was `P`. If so, return the corresponding
     /// channel; otherwise, return all the other possibilities.
@@ -258,10 +252,7 @@ where
     }
 }
 
-impl<'a, Tx, Rx, E: Environment> Branches<Tx, Rx, (), E>
-where
-    E::Dual: Environment,
-{
+impl<'a, Tx, Rx, E: Environment> Branches<Tx, Rx, (), E> {
     /// Attempt to eliminate an empty [`Branches`], returning an error if the originating
     /// discriminant for this set of protocol choices was out of range.
     ///
@@ -372,8 +363,6 @@ pub struct UnsplitError<Tx, Rx, P, E>
 where
     P: Actionable<E, Action = P, Env = E>,
     E: Environment,
-    E::Dual: Environment,
-    <P::Env as EachSession>::Dual: Environment,
 {
     /// The transmit-only half.
     pub tx: CanonicalChan<Available<Tx>, Unavailable<Rx>, P, E>,
@@ -388,8 +377,6 @@ where
     Rx: std::fmt::Debug,
     P: Actionable<E, Action = P, Env = E> + std::fmt::Debug,
     E: Environment + std::fmt::Debug,
-    E::Dual: Environment,
-    <P::Env as EachSession>::Dual: Environment,
 {
 }
 
@@ -397,8 +384,6 @@ impl<Tx, Rx, P, E> std::fmt::Display for UnsplitError<Tx, Rx, P, E>
 where
     P: Actionable<E, Action = P, Env = E>,
     E: Environment,
-    E::Dual: Environment,
-    <P::Env as EachSession>::Dual: Environment,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "cannot `Chan::unsplit_with` two unrelated channels")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 //! - gracefully handles runtime protocol violations, introducing **no panics**; and
 //! - allows for **full duplex concurrent communication**, if specified in its type, while
 //!   preserving all the same session-type safety guarantees.
+//! - allows the expression of **context free sessions**, a more general form of session that than
+//!   most other session typing libraries.
 //!
 //! Together, these make Dialectic ideal for writing networked services that need to ensure **high
 //! levels of availability** and **complex protocol correctness properties** in the real world,

--- a/src/new_session.rs
+++ b/src/new_session.rs
@@ -6,11 +6,12 @@ use super::*;
 /// # Examples
 ///
 /// ```
-/// use dialectic::*;
+/// use dialectic::prelude::*;
+/// use dialectic::backend::mpsc;
 ///
 /// # #[tokio::main]
 /// # async fn main() {
-/// let (c1, c2) = <Send<String>>::channel(backend::mpsc::unbounded_channel);
+/// let (c1, c2) = <Send<String>>::channel(mpsc::unbounded_channel);
 /// // do something with these channels...
 /// #   c1.unwrap();
 /// #   c2.unwrap();
@@ -29,10 +30,11 @@ use super::*;
 ///
 /// ```compile_fail
 /// use dialectic::*;
+/// use dialectic::backend::mpsc;
 ///
 /// # #[tokio::main]
 /// # async fn main() {
-/// let (c1, c2) = <Loop<Continue>>::channel(backend::mpsc::unbounded_channel);
+/// let (c1, c2) = <Loop<Continue>>::channel(mpsc::unbounded_channel);
 /// #   c1.unwrap();
 /// #   c2.unwrap();
 /// # }
@@ -74,11 +76,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use dialectic::*;
+    /// use dialectic::prelude::*;
+    /// use dialectic::backend::mpsc;
     ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// let (c1, c2) = Done::channel(backend::mpsc::unbounded_channel);
+    /// let (c1, c2) = Done::channel(mpsc::unbounded_channel);
     /// # }
     /// ```
     fn channel<Tx, Rx>(
@@ -95,13 +98,14 @@ where
     /// # Examples
     ///
     /// ```
-    /// use dialectic::*;
+    /// use dialectic::prelude::*;
+    /// use dialectic::backend::mpsc;
     ///
     /// # #[tokio::main]
     /// # async fn main() {
     /// let (c1, c2) = Done::bichannel(
-    ///     backend::mpsc::unbounded_channel,
-    ///     || backend::mpsc::channel(1),
+    ///     mpsc::unbounded_channel,
+    ///     || mpsc::channel(1),
     /// );
     /// # }
     /// ```
@@ -125,11 +129,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use dialectic::*;
+    /// use dialectic::prelude::*;
+    /// use dialectic::backend::mpsc;
     ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// let (mut tx, mut rx) = backend::mpsc::unbounded_channel();
+    /// let (mut tx, mut rx) = mpsc::unbounded_channel();
     /// let c = Done::wrap(&mut tx, &mut rx);  // you can wrap &mut references
     /// c.close();                            // whose lifetimes end when the channel is closed,
     /// let c = Done::wrap(tx, rx);            // or you can wrap owned values
@@ -162,6 +167,6 @@ where
     }
 
     fn wrap<Tx, Rx>(tx: Tx, rx: Rx) -> Chan<Tx, Rx, Self> {
-        unsafe { canonical::CanonicalChan::with_env(tx, rx) }
+        canonical::CanonicalChan::from_raw_unchecked(tx, rx)
     }
 }

--- a/src/new_session.rs
+++ b/src/new_session.rs
@@ -63,8 +63,6 @@ pub trait NewSession
 where
     Self: Actionable,
     Self::Dual: Actionable,
-    <Self::Env as EachSession>::Dual: Environment,
-    <<Self::Dual as Actionable>::Env as EachSession>::Dual: Environment,
 {
     /// Given a closure which generates a uni-directional underlying transport channel, create a
     /// pair of dual [`Chan`]s which communicate over the transport channels resulting from these
@@ -145,8 +143,6 @@ impl<P> NewSession for P
 where
     Self: Actionable,
     Self::Dual: Actionable,
-    <Self::Env as EachSession>::Dual: Environment,
-    <<Self::Dual as Actionable>::Env as EachSession>::Dual: Environment,
 {
     fn channel<Tx, Rx>(
         mut make: impl FnMut() -> (Tx, Rx),

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -11,7 +11,7 @@
 //! Let's write our first session type:
 //!
 //! ```
-//! use dialectic::*;
+//! use dialectic::prelude::*;
 //!
 //! type JustSendOneString = Send<String, Done>;
 //! ```
@@ -25,7 +25,7 @@
 //! [`Recv`]:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use static_assertions::assert_type_eq_all;
 //! assert_type_eq_all!(<Send<String, Done> as Session>::Dual, Recv<String, Done>);
 //! ```
@@ -34,7 +34,7 @@
 //! the rest of the session is `Done`:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use static_assertions::assert_type_eq_all;
 //! assert_type_eq_all!(Send<String>, Send<String, Done>);
 //! assert_type_eq_all!(Recv<String>, Recv<String, Done>);
@@ -48,7 +48,7 @@
 //! extensible, meaning you can choose your own transport if you want.
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! use dialectic::backend::mpsc;
 //! ```
 //!
@@ -59,7 +59,7 @@
 //! underlying channel type.
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
@@ -69,7 +69,7 @@
 //! to the given session type, and `c2`'s type corresponds to its dual:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! # let (c1, c2) = JustSendOneString::channel(|| mpsc::channel(1));
@@ -83,7 +83,7 @@
 //! runtime, provided the underlying transport channel is of a compatible type.
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
@@ -119,7 +119,7 @@
 //! to a new channel.
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
@@ -175,7 +175,7 @@
 //! channel from above:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! type JustSendOneString = Send<String, Done>;
 //! ```
 //!
@@ -184,7 +184,7 @@
 //! If we try to send on the end of the channel that's meant to receive...
 //!
 //! ```compile_fail
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
@@ -204,7 +204,7 @@
 //! If we try to receive the wrong type of thing...
 //!
 //! ```compile_fail
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
@@ -229,7 +229,7 @@
 //! of messages. If we try to send twice in a row...
 //!
 //! ```compile_fail
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
@@ -262,7 +262,7 @@
 //! from:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use static_assertions::assert_type_eq_all;
 //! assert_type_eq_all!(
 //!     <Offer<(Send<String>, Recv<i64>)> as Session>::Dual,
@@ -270,9 +270,9 @@
 //! );
 //! ```
 //!
-//! Just as the [`send`](CanonicalChan::send) and [`recv`](CanonicalChan::recv) methods
-//! enact the [`Send`] and [`Recv`] session types, the [`choose`](CanonicalChan::choose)
-//! method and [`offer!`](crate::offer) macro enact the [`Choose`] and [`Offer`] session types.
+//! Just as the [`send`](CanonicalChan::send) and [`recv`](CanonicalChan::recv) methods enact the
+//! [`Send`] and [`Recv`] session types, the [`choose`](CanonicalChan::choose) method and
+//! [`offer!`](crate::offer) macro enact the [`Choose`] and [`Offer`] session types.
 //!
 //! Suppose we want to offer a choice between two protocols: either sending a single integer
 //! (`Send<i64>`) or receiving a string (`Recv<String>`). Correspondingly, the other end of the
@@ -280,12 +280,11 @@
 //! either selection by enacting the protocol chosen.
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type JustSendOneString = Send<String, Done>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use dialectic::constants::*;
 //!
 //! let (c1, c2) = <Offer<(Send<i64>, Recv<String>)>>::channel(|| mpsc::channel(1));
 //!
@@ -320,13 +319,14 @@
 //! want to bind a channel name to the result of the `offer!`, each expression must step the channel
 //! forward to an identical session type (in the case above, that's `Done`).
 //!
-//! Dually, to select an offered option, you can call the [`choose`](CanonicalChan::choose)
-//! method on a channel, passing it as input a constant corresponding to the index of the choice.
-//! These constants are *not* Rust's built-in numeric types, but rather [unary type-level
+//! Dually, to select an offered option, you can call the [`choose`](CanonicalChan::choose) method
+//! on a channel, passing it as input a constant corresponding to the index of the choice. These
+//! constants are *not* Rust's built-in numeric types, but rather [unary type-level
 //! numbers](crate::types::unary). Dialectic supports up to 128 possible choices in an `Offer` or
-//! `Choose`, and the corresponding constants [`_0`](crate::constants::_0),
-//! [`_1`](crate::constants::_1), [`_2`](crate::constants::_2), ... [`_127`](crate::constants::_127)
-//! are defined in the [`constants`](crate::constants) module.
+//! `Choose`, and the corresponding constants [`_0`](crate::types::unary::constants::_0),
+//! [`_1`](crate::types::unary::constants::_1), [`_2`](crate::types::unary::constants::_2), ...
+//! [`_127`](crate::types::unary::constants::_127) are defined in the
+//! [`constants`](crate::types::unary::constants) module.
 //!
 //! # Looping back
 //!
@@ -339,7 +339,7 @@
 //! could describe this protocol using the [`Loop`], [`Continue`], and [`Break`] types:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! type QuerySum = Loop<Choose<(Send<i64, Continue>, Recv<i64, Break>)>>;
 //! ```
 //!
@@ -347,7 +347,7 @@
 //! `Break` is `Break`, so we know the other end of this channel will need to implement:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use static_assertions::assert_type_eq_all;
 //! # type QuerySum = Loop<Choose<(Send<i64, Continue>, Recv<i64, Break>)>>;
 //! type ComputeSum = Loop<Offer<(Recv<i64, Continue>, Send<i64, Break>)>>;
@@ -360,7 +360,7 @@
 //! looping session type, even though the session after [`Send`] is [`Done`]:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! type SendForever = Loop<Send<i64, Done>>;
 //! ```
 //!
@@ -368,7 +368,7 @@
 //! these two types in our `QuerySum` and `ComputeSum` to omit the explicit [`Continue`]:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! type QuerySum = Loop<Choose<(Send<i64>, Recv<i64, Break>)>>;
 //! type ComputeSum = Loop<Offer<(Recv<i64>, Send<i64, Break>)>>;
 //! ```
@@ -380,13 +380,12 @@
 //! Recv<i64>)>` once more.
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
 //! # type QuerySum = Loop<Choose<(Send<i64>, Recv<i64, Break>)>>;
 //! # type ComputeSum = Loop<Offer<(Recv<i64>, Send<i64, Break>)>>;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # use dialectic::constants::*;
 //! #
 //! let (mut c1, mut c2) = QuerySum::channel(|| mpsc::channel(1));
 //!
@@ -437,15 +436,15 @@
 //!
 //! ## Automatic looping
 //!
-//! You may have noticed how in the example above, [`choose`](CanonicalChan::choose) can be
-//! called on `c1` even though the outermost part of `c1`'s session type `QuerySum` would seem not
-//! to begin with [`Choose`]. This is true in general: if the session type of a [`Chan`] is a
-//! [`Loop`], [`Break`], or [`Continue`] that leads to a session type for which a given operation is
-//! valid, that operation is valid on the [`Chan`]. In the instance above, calling
-//! [`choose`](CanonicalChan::choose) on a [`Chan`] with session type `Loop<Choose<...>>`
-//! works, no matter how many `Loop`s enclose the `Choose`. Similarly, if a `Chan`'s type is
-//! `Continue`, whatever operation would be valid for the session type at the start of the
-//! corresponding `Loop` is valid for that `Chan`.
+//! You may have noticed how in the example above, [`choose`](CanonicalChan::choose) can be called
+//! on `c1` even though the outermost part of `c1`'s session type `QuerySum` would seem not to begin
+//! with [`Choose`]. This is true in general: if the session type of a [`Chan`] is a [`Loop`],
+//! [`Break`], or [`Continue`] that leads to a session type for which a given operation is valid,
+//! that operation is valid on the [`Chan`]. In the instance above, calling
+//! [`choose`](CanonicalChan::choose) on a [`Chan`] with session type `Loop<Choose<...>>` works, no
+//! matter how many `Loop`s enclose the `Choose`. Similarly, if a `Chan`'s type is `Continue`,
+//! whatever operation would be valid for the session type at the start of the corresponding `Loop`
+//! is valid for that `Chan`.
 //!
 //! This behavior is enabled by the [`Actionable`] trait, which defines what the next "real action"
 //! on a session type is. For [`Send`], [`Recv`], [`Offer`], [`Choose`], and [`Split`] (the final
@@ -465,21 +464,21 @@
 //! executing certain portions of them in parallel.
 //!
 //! Dialectic incorporates this option into its type system with the [`Split`] type. A channel with
-//! a session type of `Split<P, Q>` can be [`split`](CanonicalChan::split) into a send-only
-//! end with the session type `P` and a receive-only end with the session type `Q`, which can then
-//! be used concurrently. In the example below, the two ends of a channel **concurrently swap** a
+//! a session type of `Split<P, Q>` can be [`split`](CanonicalChan::split) into a send-only end with
+//! the session type `P` and a receive-only end with the session type `Q`, which can then be used
+//! concurrently. In the example below, the two ends of a channel **concurrently swap** a
 //! `Vec<usize>` and a `String`. If this example were run over a network and these values were
 //! large, this could represent a significant reduction in runtime.
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! type SwapVecString = Split<Send<Vec<usize>>, Recv<String>>;
 //! ```
 //!
 //! The dual of `Split<P, Q>` is `Split<Q::Dual, P::Dual>`:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use static_assertions::assert_type_eq_all;
 //! assert_type_eq_all!(
 //!     <Split<Send<Vec<usize>>, Recv<String>> as Session>::Dual,
@@ -493,9 +492,8 @@
 //! Now, let's use a channel of this session type to enact a concurrent swap:
 //!
 //! ```
-//! # use dialectic::*;
+//! # use dialectic::prelude::*;
 //! # use dialectic::backend::mpsc;
-//! # use dialectic::constants::*;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # type SwapVecString = Split<Send<Vec<usize>>, Recv<String>>;
@@ -556,9 +554,9 @@
 //! - It's a type error to [`Recv`] or [`Offer`] on the transmit-only end.
 //! - You can [`unsplit_with`](CanonicalChan::unsplit_with) the two ends again only once their
 //!   session types match each other.
-//! - It's a runtime [`UnsplitError`] to attempt to
-//!   [`unsplit_with`](CanonicalChan::unsplit_with) two [`Chan`]s which did not originate from
-//!   the same call to [`split`](CanonicalChan::split), even if their types match.
+//! - It's a runtime [`UnsplitError`] to attempt to [`unsplit_with`](CanonicalChan::unsplit_with)
+//!   two [`Chan`]s which did not originate from the same call to [`split`](CanonicalChan::split),
+//!   even if their types match.
 //!
 //! # Wrapping up
 //!

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -664,4 +664,3 @@
 // Import the whole crate so the docs above can link appropriately.
 #![allow(unused_imports)]
 use crate::prelude::*;
-use static_assertions;

--- a/src/types.rs
+++ b/src/types.rs
@@ -127,34 +127,18 @@ pub trait Environment: Any {
     /// The depth of a session environment is the number of loops to which a [`Continue`] could
     /// jump, i.e. the number of session types in the session environment.
     type Depth: Unary;
-
-    /// The same environment, headed with `Done` rather than `Continue` if inside a [`Loop`]. This
-    /// allows [`Done`] to step to the second session in [`Seq`], even if [`Seq`] occurs inside a
-    /// [`Loop`].
-    type MakeDone: Environment<Depth = Self::Depth, MakeDone = Self::MakeDone>;
 }
 
 impl Environment for () {
     type Depth = Z;
-    type MakeDone = Self;
 }
 
-impl<P, Rest> Environment for ((Done, P), Rest)
+impl<P, Rest> Environment for (P, Rest)
 where
     P: Scoped<S<Rest::Depth>>,
     Rest: Environment,
 {
     type Depth = S<Rest::Depth>;
-    type MakeDone = Self;
-}
-
-impl<P, Rest> Environment for ((Continue, P), Rest)
-where
-    P: Scoped<S<Rest::Depth>>,
-    Rest: Environment,
-{
-    type Depth = S<Rest::Depth>;
-    type MakeDone = ((Done, P), Rest);
 }
 
 /// A session type is *scoped* for a given environment depth `N` if it [`Continue`]s no more than

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,7 @@
 //! The types in this module enumerate the shapes of all expressible sessions.
 
+use std::any::Any;
+
 use crate::prelude::*;
 pub use unary::types::*;
 pub use unary::{LessThan, Unary, S, Z};
@@ -121,7 +123,7 @@ where
 
 /// A valid session environment is a type-level list of session types, each of which may refer by
 /// [`Continue`] index to any other session in the list which is *below or including* itself.
-pub trait Environment {
+pub trait Environment: Any {
     /// The depth of a session environment is the number of loops to which a [`Continue`] could
     /// jump, i.e. the number of session types in the session environment.
     type Depth: Unary;
@@ -203,10 +205,12 @@ where
 }
 
 mod sealed {
+    use std::any::Any;
+
     use super::*;
 
     /// Seal the [`Session`] trait so only types defined in this crate can be session types.
-    pub trait IsSession {}
+    pub trait IsSession: Any {}
 
     /// Seal the [`EachSession`] trait so it can't be extended in weird ways.
     pub trait EachSession {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -129,7 +129,15 @@ impl Environment for () {
     type Depth = Z;
 }
 
-impl<P, Ps> Environment for (P, Ps)
+impl<P, Ps> Environment for ((Done, P), Ps)
+where
+    P: Scoped<S<Ps::Depth>>,
+    Ps: Environment,
+{
+    type Depth = S<Ps::Depth>;
+}
+
+impl<P, Ps> Environment for ((Continue, P), Ps)
 where
     P: Scoped<S<Ps::Depth>>,
     Ps: Environment,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 //! The types in this module enumerate the shapes of all expressible sessions.
 
-use super::*;
+use crate::prelude::*;
 pub use unary::types::*;
-pub use unary::{constants, LessThan, Unary, S, Z};
+pub use unary::{LessThan, Unary, S, Z};
 
 pub mod tuple;
 pub mod unary;
@@ -176,8 +176,7 @@ impl<N: Unary, P: Scoped<N>, Ps: EachScoped<N>> EachScoped<N> for (P, Ps) {}
 ///
 /// ```
 /// # use static_assertions::assert_type_eq_all;
-/// use dialectic::Select;
-/// use dialectic::unary::types::*;
+/// use dialectic::prelude::*;
 ///
 /// assert_type_eq_all!(<(_0, (_1, (_2, ()))) as Select<_0>>::Selected, _0);
 /// assert_type_eq_all!(<(_0, (_1, (_2, ()))) as Select<_2>>::Selected, _2);

--- a/src/types/break.rs
+++ b/src/types/break.rs
@@ -30,6 +30,7 @@ where
     type Env = ();
 }
 
+/// Break from a non-outermost loop tagged as `Done`: be done with everything.
 impl<K, P, Q, Rest> Actionable<((K, P), ((Done, Q), Rest))> for Break<Z>
 where
     Q: Scoped<S<<Rest as Environment>::Depth>>,
@@ -39,7 +40,7 @@ where
     Z: LessThan<<((K, P), ((Done, Q), Rest)) as Environment>::Depth>,
 {
     type Action = Done;
-    type Env = ((Done, Q), Rest);
+    type Env = ();
 }
 
 /// Break from a non-outermost loop: continue whatever loop we broke into.

--- a/src/types/break.rs
+++ b/src/types/break.rs
@@ -22,54 +22,41 @@ impl<N: Unary + Any> Session for Break<N> {
 impl<N: Unary + Any, M: Unary + Any> Scoped<M> for Break<N> where N: LessThan<M> {}
 
 /// When in the outermost loop, [`Break`] exits that loop and finishes the session.
-impl<K, P> Actionable<((K, P), ())> for Break<Z>
+impl<P> Actionable<(P, ())> for Break<Z>
 where
     P: Scoped<S<Z>>,
-    ((K, P), ()): Environment + 'static,
-    Z: LessThan<<((K, P), ()) as Environment>::Depth>,
-{
-    type Action = Done;
-    type Env = ();
-}
-
-/// Break from a non-outermost loop tagged as `Done`: be done with everything.
-impl<K, P, Q, Rest> Actionable<((K, P), ((Done, Q), Rest))> for Break<Z>
-where
-    Q: Scoped<S<<Rest as Environment>::Depth>>,
-    ((K, P), ((Done, Q), Rest)): Environment + 'static,
-    ((Done, Q), Rest): Environment,
-    Rest: Environment,
-    Z: LessThan<<((K, P), ((Done, Q), Rest)) as Environment>::Depth>,
+    (P, ()): Environment + 'static,
+    Z: LessThan<<(P, ()) as Environment>::Depth>,
 {
     type Action = Done;
     type Env = ();
 }
 
 /// Break from a non-outermost loop: continue whatever loop we broke into.
-impl<K, P, Q, Rest> Actionable<((K, P), ((Continue, Q), Rest))> for Break<Z>
+impl<P, Q, Rest> Actionable<(P, (Q, Rest))> for Break<Z>
 where
-    Q: Actionable<((Continue, Q), Rest)>,
+    Q: Actionable<(Q, Rest)>,
     P: Scoped<S<S<<Rest as Environment>::Depth>>>,
     Q: Scoped<S<<Rest as Environment>::Depth>>,
     Q::Env: Environment,
-    ((K, P), ((Continue, Q), Rest)): Environment + 'static,
-    ((Continue, Q), Rest): Environment,
+    (P, (Q, Rest)): Environment + 'static,
+    (Q, Rest): Environment,
     Rest: Environment,
-    Z: LessThan<<((K, P), ((Continue, Q), Rest)) as Environment>::Depth>,
+    Z: LessThan<<(P, (Q, Rest)) as Environment>::Depth>,
 {
     type Action = Q::Action;
     type Env = Q::Env;
 }
 
 /// Inductive case: break one less level from one less loop.
-impl<K, N: Unary, P, Rest> Actionable<((K, P), Rest)> for Break<S<N>>
+impl<N: Unary, P, Rest> Actionable<(P, Rest)> for Break<S<N>>
 where
     P: Scoped<S<<Rest as Environment>::Depth>>,
     N: LessThan<Rest::Depth>,
     Break<N>: Actionable<Rest>,
-    ((K, P), Rest): Environment + 'static,
+    (P, Rest): Environment + 'static,
     Rest: Environment,
-    S<N>: LessThan<<((K, P), Rest) as Environment>::Depth>,
+    S<N>: LessThan<<(P, Rest) as Environment>::Depth>,
 {
     type Action = <Break<N> as Actionable<Rest>>::Action;
     type Env = <Break<N> as Actionable<Rest>>::Env;

--- a/src/types/break.rs
+++ b/src/types/break.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use super::sealed::IsSession;
 use super::*;
 
@@ -8,22 +10,22 @@ use super::*;
 pub struct Break<N: Unary = Z>(pub N);
 
 /// [`Break`] is a constructor for a session type.
-impl<N: Unary> IsSession for Break<N> {}
+impl<N: Unary + Any> IsSession for Break<N> {}
 
 /// All [`Break`]s are valid session types.
-impl<N: Unary> Session for Break<N> {
+impl<N: Unary + Any> Session for Break<N> {
     /// [`Break`] is self-dual.
     type Dual = Break<N>;
 }
 
 /// A [`Break`] is well-[`Scoped`] if it refers to a loop that it is inside of.
-impl<N: Unary, M: Unary> Scoped<M> for Break<N> where N: LessThan<M> {}
+impl<N: Unary + Any, M: Unary + Any> Scoped<M> for Break<N> where N: LessThan<M> {}
 
 /// When in the outermost loop, [`Break`] exits that loop and finishes the session.
 impl<K, P> Actionable<((K, P), ())> for Break<Z>
 where
     P: Scoped<S<Z>>,
-    ((K, P), ()): Environment,
+    ((K, P), ()): Environment + 'static,
     Z: LessThan<<((K, P), ()) as Environment>::Depth>,
 {
     type Action = Done;
@@ -34,7 +36,7 @@ where
 impl<K, P, Q, Rest> Actionable<((K, P), ((Done, Q), Rest))> for Break<Z>
 where
     Q: Scoped<S<<Rest as Environment>::Depth>>,
-    ((K, P), ((Done, Q), Rest)): Environment,
+    ((K, P), ((Done, Q), Rest)): Environment + 'static,
     ((Done, Q), Rest): Environment,
     Rest: Environment,
     Z: LessThan<<((K, P), ((Done, Q), Rest)) as Environment>::Depth>,
@@ -50,7 +52,7 @@ where
     P: Scoped<S<S<<Rest as Environment>::Depth>>>,
     Q: Scoped<S<<Rest as Environment>::Depth>>,
     Q::Env: Environment,
-    ((K, P), ((Continue, Q), Rest)): Environment,
+    ((K, P), ((Continue, Q), Rest)): Environment + 'static,
     ((Continue, Q), Rest): Environment,
     Rest: Environment,
     Z: LessThan<<((K, P), ((Continue, Q), Rest)) as Environment>::Depth>,
@@ -65,7 +67,7 @@ where
     P: Scoped<S<<Rest as Environment>::Depth>>,
     N: LessThan<Rest::Depth>,
     Break<N>: Actionable<Rest>,
-    ((K, P), Rest): Environment,
+    ((K, P), Rest): Environment + 'static,
     Rest: Environment,
     S<N>: LessThan<<((K, P), Rest) as Environment>::Depth>,
 {

--- a/src/types/break.rs
+++ b/src/types/break.rs
@@ -22,6 +22,7 @@ impl<N: Unary, M: Unary> Scoped<M> for Break<N> where N: LessThan<M> {}
 /// When in the outermost loop, [`Break`] exits that loop and finishes the session.
 impl<P> Actionable<(P, ())> for Break<Z>
 where
+    P: Session,
     (P, ()): Environment,
     <(P, ()) as EachSession>::Dual: Environment,
     Z: LessThan<<(P, ()) as Environment>::Depth>, // this is always true but Rust doesn't know it
@@ -34,17 +35,10 @@ where
 impl<P, Q, Rest> Actionable<(P, (Q, Rest))> for Break<Z>
 where
     Q: Actionable<(Q, Rest)>,
-    Q: Scoped<S<<Rest as Environment>::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
     P: Scoped<S<S<<Rest as Environment>::Depth>>>,
-    P: Scoped<S<S<<Rest::Dual as Environment>::Depth>>>,
-    P::Dual: Scoped<S<S<<Rest as Environment>::Depth>>>,
-    P::Dual: Scoped<S<S<<Rest::Dual as Environment>::Depth>>>,
-    Q::Dual: Scoped<S<<Rest as Environment>::Depth>>,
-    Q::Dual: Scoped<S<<Rest::Dual as Environment>::Depth>>,
+    Q: Scoped<S<<Rest as Environment>::Depth>>,
     Q::Env: Environment,
     Rest: Environment,
-    Rest::Dual: Environment,
-    <Q::Env as EachSession>::Dual: Environment,
 {
     type Action = Q::Action;
     type Env = Q::Env;
@@ -53,13 +47,10 @@ where
 /// Inductive case: break one less level from one less loop.
 impl<N: Unary, P, Rest> Actionable<(P, Rest)> for Break<S<N>>
 where
+    P: Scoped<S<<Rest as Environment>::Depth>>,
     N: LessThan<Rest::Depth>,
     Break<N>: Actionable<Rest>,
-    P: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
-    P::Dual: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
     Rest: Environment,
-    Rest::Dual: Environment,
-    <<Break<N> as Actionable<Rest>>::Env as EachSession>::Dual: Environment,
 {
     type Action = <Break<N> as Actionable<Rest>>::Action;
     type Env = <Break<N> as Actionable<Rest>>::Env;

--- a/src/types/choose.rs
+++ b/src/types/choose.rs
@@ -35,7 +35,6 @@ where
     <Choices::AsList as EachSession>::Dual: List + EachSession,
     Choices::AsList: EachScoped<E::Depth>,
     E: Environment,
-    E::Dual: Environment,
 {
     type Action = Choose<Choices>;
     type Env = E;

--- a/src/types/choose.rs
+++ b/src/types/choose.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use super::sealed::IsSession;
 use super::*;
 
@@ -10,9 +12,9 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Choose<Choices>(pub Choices);
 
-impl<Choices> IsSession for Choose<Choices> {}
+impl<Choices: Any> IsSession for Choose<Choices> {}
 
-impl<Choices> Session for Choose<Choices>
+impl<Choices: Any> Session for Choose<Choices>
 where
     Choices: Tuple,
     Choices::AsList: EachSession,
@@ -21,14 +23,14 @@ where
     type Dual = Offer<<<Choices::AsList as EachSession>::Dual as List>::AsTuple>;
 }
 
-impl<N: Unary, Choices: Tuple> Scoped<N> for Choose<Choices>
+impl<N: Unary, Choices: Tuple + Any> Scoped<N> for Choose<Choices>
 where
     Choices::AsList: EachScoped<N>,
     <Choices::AsList as EachSession>::Dual: List,
 {
 }
 
-impl<E, Choices> Actionable<E> for Choose<Choices>
+impl<E, Choices: Any> Actionable<E> for Choose<Choices>
 where
     Choices: Tuple,
     Choices::AsList: EachSession,

--- a/src/types/continue.rs
+++ b/src/types/continue.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use super::sealed::IsSession;
 use super::*;
 
@@ -7,13 +9,13 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Continue<N: Unary = Z>(pub N);
 
-impl<N: Unary> IsSession for Continue<N> {}
+impl<N: Unary + Any> IsSession for Continue<N> {}
 
-impl<N: Unary> Session for Continue<N> {
+impl<N: Unary + Any> Session for Continue<N> {
     type Dual = Continue<N>;
 }
 
-impl<N: Unary, M: Unary> Scoped<M> for Continue<N> where N: LessThan<M> {}
+impl<N: Unary + Any, M: Unary + Any> Scoped<M> for Continue<N> where N: LessThan<M> {}
 
 impl<E, K, P, Rest, N: Unary> Actionable<E> for Continue<N>
 where

--- a/src/types/continue.rs
+++ b/src/types/continue.rs
@@ -22,14 +22,7 @@ where
     E::Selected: Actionable<(E::Selected, E::Remainder)>,
     E::Selected: Scoped<S<<E::Remainder as Environment>::Depth>>,
     <E::Selected as Session>::Dual: Scoped<S<<E::Remainder as Environment>::Depth>>,
-    E::Selected: Scoped<S<<<E::Remainder as EachSession>::Dual as Environment>::Depth>>,
-    <E::Selected as Session>::Dual:
-        Scoped<S<<<E::Remainder as EachSession>::Dual as Environment>::Depth>>,
-    E::Dual: Environment,
     E::Remainder: Environment,
-    <E::Remainder as EachSession>::Dual: Environment,
-    <<E::Selected as Actionable<(E::Selected, E::Remainder)>>::Env as EachSession>::Dual:
-        Environment,
 {
     type Action = <E::Selected as Actionable<(E::Selected, E::Remainder)>>::Action;
     type Env = <E::Selected as Actionable<(E::Selected, E::Remainder)>>::Env;

--- a/src/types/continue.rs
+++ b/src/types/continue.rs
@@ -17,18 +17,18 @@ impl<N: Unary + Any> Session for Continue<N> {
 
 impl<N: Unary + Any, M: Unary + Any> Scoped<M> for Continue<N> where N: LessThan<M> {}
 
-impl<E, K, P, Rest, N: Unary> Actionable<E> for Continue<N>
+impl<E, P, Rest, N: Unary> Actionable<E> for Continue<N>
 where
-    E: Select<N, Selected = (K, P), Remainder = Rest> + Environment,
+    E: Select<N, Selected = P, Remainder = Rest> + Environment,
     Continue<N>: Scoped<E::Depth>,
-    P: Actionable<((K, P), Rest)>,
+    P: Actionable<(P, Rest)>,
     P: Scoped<S<<Rest as Environment>::Depth>>,
     P::Dual: Scoped<S<Rest::Depth>>,
-    ((K, P), Rest): Environment,
+    (P, Rest): Environment,
     Rest: Environment,
 {
-    type Action = <P as Actionable<((K, P), Rest)>>::Action;
-    type Env = <P as Actionable<((K, P), Rest)>>::Env;
+    type Action = <P as Actionable<(P, Rest)>>::Action;
+    type Env = <P as Actionable<(P, Rest)>>::Env;
 }
 
 #[cfg(test)]

--- a/src/types/done.rs
+++ b/src/types/done.rs
@@ -18,13 +18,22 @@ impl Actionable<()> for Done {
     type Env = ();
 }
 
-/// When inside a `Loop`, `Done` repeats the innermost loop.
-impl<P, Rest> Actionable<(P, Rest)> for Done
+impl<P, Rest> Actionable<((Done, P), Rest)> for Done
 where
     P: Scoped<S<<Rest as Environment>::Depth>>,
-    Continue: Actionable<(P, Rest)>,
     Rest: Environment,
 {
-    type Action = <Continue as Actionable<(P, Rest)>>::Action;
-    type Env = <Continue as Actionable<(P, Rest)>>::Env;
+    type Action = Done;
+    type Env = ((Done, P), Rest);
+}
+
+/// When inside a `Loop`, `Done` repeats the innermost loop.
+impl<P, Rest> Actionable<((Continue, P), Rest)> for Done
+where
+    P: Scoped<S<<Rest as Environment>::Depth>>,
+    Continue: Actionable<((Continue, P), Rest)>,
+    Rest: Environment,
+{
+    type Action = <Continue as Actionable<((Continue, P), Rest)>>::Action;
+    type Env = <Continue as Actionable<((Continue, P), Rest)>>::Env;
 }

--- a/src/types/done.rs
+++ b/src/types/done.rs
@@ -13,27 +13,7 @@ impl Session for Done {
 
 impl<N: Unary> Scoped<N> for Done {}
 
-impl Actionable<()> for Done {
+impl<E: Environment> Actionable<E> for Done {
     type Action = Done;
     type Env = ();
-}
-
-impl<P, Rest> Actionable<((Done, P), Rest)> for Done
-where
-    P: Scoped<S<<Rest as Environment>::Depth>>,
-    Rest: Environment,
-{
-    type Action = Done;
-    type Env = ();
-}
-
-/// When inside a `Loop`, `Done` repeats the innermost loop.
-impl<P, Rest> Actionable<((Continue, P), Rest)> for Done
-where
-    P: Scoped<S<<Rest as Environment>::Depth>>,
-    Continue: Actionable<((Continue, P), Rest)>,
-    Rest: Environment,
-{
-    type Action = <Continue as Actionable<((Continue, P), Rest)>>::Action;
-    type Env = <Continue as Actionable<((Continue, P), Rest)>>::Env;
 }

--- a/src/types/done.rs
+++ b/src/types/done.rs
@@ -24,7 +24,7 @@ where
     Rest: Environment,
 {
     type Action = Done;
-    type Env = ((Done, P), Rest);
+    type Env = ();
 }
 
 /// When inside a `Loop`, `Done` repeats the innermost loop.

--- a/src/types/done.rs
+++ b/src/types/done.rs
@@ -11,22 +11,19 @@ impl Session for Done {
     type Dual = Done;
 }
 
+impl<N: Unary> Scoped<N> for Done {}
+
 impl Actionable<()> for Done {
     type Action = Done;
     type Env = ();
 }
 
-impl<N: Unary> Scoped<N> for Done {}
-
 /// When inside a `Loop`, `Done` repeats the innermost loop.
 impl<P, Rest> Actionable<(P, Rest)> for Done
 where
+    P: Scoped<S<<Rest as Environment>::Depth>>,
     Continue: Actionable<(P, Rest)>,
-    P: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
-    P::Dual: Scoped<S<Rest::Depth>> + Scoped<S<<Rest::Dual as Environment>::Depth>>,
     Rest: Environment,
-    Rest::Dual: Environment,
-    <<Continue as Actionable<(P, Rest)>>::Env as EachSession>::Dual: Environment,
 {
     type Action = <Continue as Actionable<(P, Rest)>>::Action;
     type Env = <Continue as Actionable<(P, Rest)>>::Env;

--- a/src/types/loop.rs
+++ b/src/types/loop.rs
@@ -17,13 +17,8 @@ impl<N: Unary, P: Scoped<S<N>>> Scoped<N> for Loop<P> {}
 impl<P, E> Actionable<E> for Loop<P>
 where
     E: Environment,
-    E::Dual: Environment,
     P: Actionable<(P, E)>,
     P: Scoped<S<E::Depth>>,
-    P: Scoped<S<<E::Dual as Environment>::Depth>>,
-    P::Dual: Scoped<S<E::Depth>>,
-    P::Dual: Scoped<S<<E::Dual as Environment>::Depth>>,
-    <P::Env as EachSession>::Dual: Environment,
 {
     type Action = <P as Actionable<(P, E)>>::Action;
     type Env = <P as Actionable<(P, E)>>::Env;

--- a/src/types/loop.rs
+++ b/src/types/loop.rs
@@ -6,7 +6,7 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Loop<P>(pub P);
 
-impl<P> IsSession for Loop<P> {}
+impl<P: IsSession> IsSession for Loop<P> {}
 
 impl<P: Session> Session for Loop<P> {
     type Dual = Loop<P::Dual>;

--- a/src/types/loop.rs
+++ b/src/types/loop.rs
@@ -17,9 +17,9 @@ impl<N: Unary, P: Scoped<S<N>>> Scoped<N> for Loop<P> {}
 impl<P, E> Actionable<E> for Loop<P>
 where
     E: Environment,
-    P: Actionable<(P, E)>,
+    P: Actionable<((Continue, P), E)>,
     P: Scoped<S<E::Depth>>,
 {
-    type Action = <P as Actionable<(P, E)>>::Action;
-    type Env = <P as Actionable<(P, E)>>::Env;
+    type Action = <P as Actionable<((Continue, P), E)>>::Action;
+    type Env = <P as Actionable<((Continue, P), E)>>::Env;
 }

--- a/src/types/loop.rs
+++ b/src/types/loop.rs
@@ -17,9 +17,9 @@ impl<N: Unary, P: Scoped<S<N>>> Scoped<N> for Loop<P> {}
 impl<P, E> Actionable<E> for Loop<P>
 where
     E: Environment,
-    P: Actionable<((Continue, P), E)>,
+    P: Actionable<(P, E)>,
     P: Scoped<S<E::Depth>>,
 {
-    type Action = <P as Actionable<((Continue, P), E)>>::Action;
-    type Env = <P as Actionable<((Continue, P), E)>>::Env;
+    type Action = <P as Actionable<(P, E)>>::Action;
+    type Env = <P as Actionable<(P, E)>>::Env;
 }

--- a/src/types/offer.rs
+++ b/src/types/offer.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use super::sealed::IsSession;
 use super::*;
 
@@ -9,9 +11,9 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Offer<Choices>(pub Choices);
 
-impl<Choices> IsSession for Offer<Choices> {}
+impl<Choices: Any> IsSession for Offer<Choices> {}
 
-impl<Choices> Session for Offer<Choices>
+impl<Choices: Any> Session for Offer<Choices>
 where
     Choices: Tuple,
     Choices::AsList: EachSession,
@@ -20,14 +22,14 @@ where
     type Dual = Choose<<<Choices::AsList as EachSession>::Dual as List>::AsTuple>;
 }
 
-impl<N: Unary, Choices: Tuple> Scoped<N> for Offer<Choices>
+impl<N: Unary, Choices: Tuple + Any> Scoped<N> for Offer<Choices>
 where
     Choices::AsList: EachScoped<N>,
     <Choices::AsList as EachSession>::Dual: List,
 {
 }
 
-impl<E, Choices> Actionable<E> for Offer<Choices>
+impl<E, Choices: Any> Actionable<E> for Offer<Choices>
 where
     Choices: Tuple,
     Choices::AsList: EachSession,

--- a/src/types/offer.rs
+++ b/src/types/offer.rs
@@ -34,7 +34,6 @@ where
     <Choices::AsList as EachSession>::Dual: List + EachSession,
     Choices::AsList: EachScoped<E::Depth>,
     E: Environment,
-    E::Dual: Environment,
 {
     type Action = Offer<Choices>;
     type Env = E;

--- a/src/types/recv.rs
+++ b/src/types/recv.rs
@@ -24,7 +24,6 @@ impl<E, T, P> Actionable<E> for Recv<T, P>
 where
     P: Scoped<E::Depth>,
     E: Environment,
-    E::Dual: Environment,
 {
     type Action = Recv<T, P>;
     type Env = E;

--- a/src/types/recv.rs
+++ b/src/types/recv.rs
@@ -1,5 +1,6 @@
 use super::sealed::IsSession;
-use super::*;
+use crate::prelude::*;
+use std::marker::PhantomData;
 
 /// Receive a message of type `T` using [`recv`](crate::CanonicalChan::recv), then continue with
 /// protocol `P`.

--- a/src/types/recv.rs
+++ b/src/types/recv.rs
@@ -1,6 +1,6 @@
 use super::sealed::IsSession;
 use crate::prelude::*;
-use std::marker::PhantomData;
+use std::{any::Any, marker::PhantomData};
 
 /// Receive a message of type `T` using [`recv`](crate::CanonicalChan::recv), then continue with
 /// protocol `P`.
@@ -13,15 +13,15 @@ use std::marker::PhantomData;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Recv<T, P = Done>(pub PhantomData<T>, pub P);
 
-impl<T, P> IsSession for Recv<T, P> {}
+impl<T: Any, P: Any> IsSession for Recv<T, P> {}
 
-impl<T, P: Session> Session for Recv<T, P> {
+impl<T: Any, P: Session> Session for Recv<T, P> {
     type Dual = Send<T, P::Dual>;
 }
 
-impl<N: Unary, T, P: Scoped<N>> Scoped<N> for Recv<T, P> {}
+impl<N: Unary, T: Any, P: Scoped<N>> Scoped<N> for Recv<T, P> {}
 
-impl<E, T, P> Actionable<E> for Recv<T, P>
+impl<E, T: Any, P> Actionable<E> for Recv<T, P>
 where
     P: Scoped<E::Depth>,
     E: Environment,

--- a/src/types/send.rs
+++ b/src/types/send.rs
@@ -24,7 +24,6 @@ impl<E, T, P> Actionable<E> for Send<T, P>
 where
     P: Scoped<E::Depth>,
     E: Environment,
-    E::Dual: Environment,
 {
     type Action = Send<T, P>;
     type Env = E;

--- a/src/types/send.rs
+++ b/src/types/send.rs
@@ -1,6 +1,6 @@
 use super::sealed::IsSession;
 use crate::prelude::*;
-use std::marker::PhantomData;
+use std::{any::Any, marker::PhantomData};
 
 /// Send a message of type `T` using [`send`](crate::CanonicalChan::send), then continue with
 /// protocol `P`.
@@ -13,15 +13,15 @@ use std::marker::PhantomData;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Send<T, P = Done>(pub PhantomData<T>, pub P);
 
-impl<T, P> IsSession for Send<T, P> {}
+impl<T: Any, P: Any> IsSession for Send<T, P> {}
 
-impl<T, P: Session> Session for Send<T, P> {
+impl<T: Any, P: Session> Session for Send<T, P> {
     type Dual = Recv<T, P::Dual>;
 }
 
-impl<N: Unary, T, P: Scoped<N>> Scoped<N> for Send<T, P> {}
+impl<N: Unary, T: Any, P: Scoped<N>> Scoped<N> for Send<T, P> {}
 
-impl<E, T, P> Actionable<E> for Send<T, P>
+impl<E, T: Any, P> Actionable<E> for Send<T, P>
 where
     P: Scoped<E::Depth>,
     E: Environment,

--- a/src/types/send.rs
+++ b/src/types/send.rs
@@ -1,5 +1,6 @@
 use super::sealed::IsSession;
-use super::*;
+use crate::prelude::*;
+use std::marker::PhantomData;
 
 /// Send a message of type `T` using [`send`](crate::CanonicalChan::send), then continue with
 /// protocol `P`.

--- a/src/types/seq.rs
+++ b/src/types/seq.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use super::sealed::IsSession;
 use super::*;
 
@@ -5,7 +7,7 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Seq<P, Q = Done>(pub P, pub Q);
 
-impl<P, Q> IsSession for Seq<P, Q> {}
+impl<P: Any, Q: Any> IsSession for Seq<P, Q> {}
 
 impl<P: Session, Q: Session> Session for Seq<P, Q> {
     type Dual = Seq<P::Dual, Q::Dual>;

--- a/src/types/seq.rs
+++ b/src/types/seq.rs
@@ -1,0 +1,24 @@
+use super::sealed::IsSession;
+use super::*;
+
+/// Sequence two sessions together, analogous to `;` in Rust.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Seq<P, Q = Done>(pub P, pub Q);
+
+impl<P, Q> IsSession for Seq<P, Q> {}
+
+impl<P: Session, Q: Session> Session for Seq<P, Q> {
+    type Dual = Seq<P::Dual, Q::Dual>;
+}
+
+impl<P: Scoped<N>, Q: Scoped<N>, N: Unary> Scoped<N> for Seq<P, Q> {}
+
+impl<E, P, Q> Actionable<E> for Seq<P, Q>
+where
+    P: Scoped<E::Depth>,
+    Q: Scoped<E::Depth>,
+    E: Environment,
+{
+    type Action = Seq<P, Q>;
+    type Env = E;
+}

--- a/src/types/split.rs
+++ b/src/types/split.rs
@@ -1,13 +1,14 @@
+use std::any::Any;
+
 use super::sealed::IsSession;
 use super::*;
 
 /// Split the connection into send-only and receive-only halves using
-/// [`split`](crate::CanonicalChan::split). These can subsequently be rejoined using
-/// [`unsplit_with`](crate::CanonicalChan::unsplit_with).
+/// [`split`](crate::CanonicalChan::split).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Split<P, Q>(pub P, pub Q);
 
-impl<P, Q> IsSession for Split<P, Q> {}
+impl<P: Any, Q: Any> IsSession for Split<P, Q> {}
 
 impl<P: Session, Q: Session> Session for Split<P, Q> {
     /// Note how the dual flips the position of `P` and `Q`, because `P::Dual` is a receiving

--- a/src/types/split.rs
+++ b/src/types/split.rs
@@ -23,7 +23,6 @@ where
     P: Scoped<E::Depth>,
     Q: Scoped<E::Depth>,
     E: Environment,
-    E::Dual: Environment,
 {
     type Action = Split<P, Q>;
     type Env = E;

--- a/src/types/unary.rs
+++ b/src/types/unary.rs
@@ -8,7 +8,7 @@ pub mod types;
 /// # Examples
 ///
 /// ```
-/// use dialectic::Z;
+/// use dialectic::prelude::Z;
 ///
 /// let zero: Z = Z;
 /// ```
@@ -20,7 +20,7 @@ pub struct Z;
 /// # Examples
 ///
 /// ```
-/// use dialectic::{S, Z};
+/// use dialectic::prelude::{S, Z};
 ///
 /// let one: S<Z> = S(Z);
 /// ```
@@ -33,8 +33,7 @@ pub struct S<N>(pub N);
 /// # Examples
 ///
 /// ```
-/// use dialectic::unary::types::*;
-/// use dialectic::Unary;
+/// use dialectic::prelude::*;
 ///
 /// assert_eq!(_0::VALUE, 0);
 /// assert_eq!(_1::VALUE, 1);
@@ -62,8 +61,7 @@ impl<N: Unary> Unary for S<N> {
 /// This compiles, because `1 < 2`:
 ///
 /// ```
-/// use dialectic::LessThan;
-/// use dialectic::unary::types::*;
+/// use dialectic::prelude::*;
 ///
 /// fn ok() where _1: LessThan<_2> {}
 /// ```
@@ -71,8 +69,7 @@ impl<N: Unary> Unary for S<N> {
 /// But this does not compile, because `2 >= 1`:
 ///
 /// ```compile_fail
-/// # use dialectic::LessThan;
-/// # use dialectic::unary::types::*;
+/// # use dialectic::prelude::*;
 /// #
 /// fn bad() where _2: LessThan<_1> {}
 /// ```
@@ -81,8 +78,7 @@ impl<N: Unary> Unary for S<N> {
 /// compile either:
 ///
 /// ```compile_fail
-/// # use dialectic::LessThan;
-/// # use dialectic::unary::types::*;
+/// # use dialectic::prelude::*;
 /// #
 /// fn bad() where _100: LessThan<_100> {}
 /// ```

--- a/src/types/unary/types.rs
+++ b/src/types/unary/types.rs
@@ -3,7 +3,7 @@
 //!
 //! Due to a limitation in Rust, at present the maximum number which can be listed here is 128.
 #![allow(missing_docs)]
-use crate::types::unary::{S, Z};
+use crate::prelude::unary::{S, Z};
 
 pub type _0 = Z;
 pub type _1 = S<_0>;


### PR DESCRIPTION
This PR implements a new primitive in the session typing language, `Seq<P, Q>`, which represents a "generalized semicolon" operator: run `P`, then run `Q`. Context-free-ness is enabled by `P` having access to the session environment, and so being able to use `Continue` to recur. This primitive is also useful in making programs more modular, because it allows a `fn(Chan<...>)` which ostensibly consumes a channel to be used as a subroutine in a larger protocol.

This change also alters the signature of `split`, turning it into a function which takes a closure that accepts the send/receive halves, and returns some value. Using the same trick as `seq`, the sending and receiving ends are recovered and reconstructed into a channel after `split` returns.