### PR TITLE
Clean up docs for backend module, slight interface tweaks

### DIFF
--- a/examples/common.rs
+++ b/examples/common.rs
@@ -45,12 +45,12 @@ where
 }
 
 /// A session-typed channel over TCP using length-delimited bincode encoding for serialization.
-pub type TcpChan<P> = dialectic::backend::serde::SymmetricalChan<
+pub type TcpChan<S> = dialectic::backend::serde::SymmetricalChan<
+    S,
     Bincode,
     LengthDelimitedCodec,
     OwnedWriteHalf,
     OwnedReadHalf,
-    P,
 >;
 
 /// Wrap a raw TCP socket in a given session type, using the length delimited bincode transport

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,16 +1,16 @@
 //! Transport backends for [`Chan`](crate::Chan), and the traits they implement in order to be used
 //! as such.
 //!
-//! A [`Chan<Tx, Rx, P, E>`](crate::Chan) is parameterized by its transmitting channel `Tx` and its
+//! A [`Chan<S, Tx, Rx>`](crate::Chan) is parameterized by its transmitting channel `Tx` and its
 //! receiving channel `Rx`. In order to use a `Chan` to run a session, these underlying channels
 //! must implement the traits [`Transmit`] and [`Receive`] for at least the types used in any given
 //! session (and in the case of [`Transmit`], for the particular calling conventions used to pass
 //! those types to [`Chan::send`](crate::Chan::send)).
 //!
-//! Additionally, in order to support [`offer!`](crate::offer) and
-//! [`choose`](crate::Chan::choose), the sending channel `Tx` must implement
-//! `Transmit<'static, Choice<N>, Val>`, and the receiving channel `Rx` must implement
-//! `Receive<Choice<N>>`, for all `N`. For more information, see [`Choice`](crate::Choice).
+//! Additionally, in order to support [`offer!`](crate::offer) and [`choose`](crate::Chan::choose),
+//! the sending channel `Tx` must implement `Transmit<Choice<N>, Val>`, and the receiving channel
+//! `Rx` must implement `Receive<Choice<N>>`, for all `N: Unary`. For more information, see
+//! [`Choice`](crate::Choice).
 
 #[doc(no_inline)]
 pub use call_by::*;

--- a/src/backend/mpsc.rs
+++ b/src/backend/mpsc.rs
@@ -10,11 +10,31 @@ use tokio::sync::mpsc;
 
 /// Shorthand for a [`Chan`](crate::Chan) using a bounded [`mpsc`](crate::backend::mpsc) [`Sender`]
 /// and [`Receiver`].
+///
+/// # Examples
+///
+/// ```
+/// use dialectic::prelude::*;
+/// use dialectic::backend::mpsc;
+///
+/// let _: (mpsc::Chan<Done>, mpsc::Chan<Done>) =
+///     Done::channel(|| mpsc::channel(1));
+/// ```
 pub type Chan<P> = crate::Chan<P, Sender<'static>, Receiver<'static>>;
 
 /// Shorthand for a [`Chan`](crate::Chan) using an unbounded [`mpsc`](crate::backend::mpsc)
 /// [`UnboundedSender`] and [`UnboundedReceiver`].
-pub type UnboundedChan<'a, P> = crate::Chan<P, UnboundedSender<'a>, UnboundedReceiver<'a>>;
+///
+/// # Examples
+///
+/// ```
+/// use dialectic::prelude::*;
+/// use dialectic::backend::mpsc;
+///
+/// let _: (mpsc::UnboundedChan<Done>, mpsc::UnboundedChan<Done>) =
+///     Done::channel(mpsc::unbounded_channel);
+/// ```
+pub type UnboundedChan<P> = crate::Chan<P, UnboundedSender<'static>, UnboundedReceiver<'static>>;
 
 /// A bounded receiver for dynamically typed values. See [`tokio::sync::mpsc::Receiver`].
 pub type Receiver<'a> = mpsc::Receiver<Box<dyn Any + Send + 'a>>;

--- a/src/backend/serde.rs
+++ b/src/backend/serde.rs
@@ -85,15 +85,15 @@ pub trait Deserializer<Input> {
 
 /// Create a [`Sender`]/[`Receiver`] pair which use the same serialization format and frame encoding
 /// in both directions.
-pub fn symmetrical<Format, Encoding, I, O, W, R>(
-    format: Format,
-    encoding: Encoding,
+pub fn symmetrical<F, E, W, R>(
+    format: F,
+    encoding: E,
     writer: W,
     reader: R,
-) -> (Sender<Format, Encoding, W>, Receiver<Format, Encoding, R>)
+) -> (Sender<F, E, W>, Receiver<F, E, R>)
 where
-    Format: Serializer<Output = O> + Deserializer<I> + Clone,
-    Encoding: Encoder<O> + Decoder<Item = I> + Clone,
+    F: Serializer + Deserializer<<E as Decoder>::Item> + Clone,
+    E: Encoder<<F as Serializer>::Output> + Decoder + Clone,
     W: AsyncWrite,
     R: AsyncRead,
 {
@@ -103,14 +103,14 @@ where
     )
 }
 
-/// A [`Chan`] for the session type `P` and the environment `E`, using a symmetrical
+/// A [`Chan`] for the session type `S` and the environment `E`, using a symmetrical
 /// serialization/encoding and the [`AsyncWrite`]/[`AsyncRead`] pair `W`/`R` as transport.
-pub type SymmetricalChan<Format, Encoding, W, R, P> =
-    Chan<P, Sender<Format, Encoding, W>, Receiver<Format, Encoding, R>>;
+pub type SymmetricalChan<S, F, E, W, R> =
+    Chan<S, Sender<F, E, W>, Receiver<F, E, R>>;
 
 /// Create a [`Sender`]/[`Receiver`] pair which use the same serialization format and frame encoding
 /// in both directions, allocating an initial capacity for the read buffer on the receiver.
-pub fn symmetrical_with_capacity<F, E, I, O, W, R>(
+pub fn symmetrical_with_capacity<F, E, W, R>(
     format: F,
     encoding: E,
     writer: W,
@@ -118,8 +118,8 @@ pub fn symmetrical_with_capacity<F, E, I, O, W, R>(
     capacity: usize,
 ) -> (Sender<F, E, W>, Receiver<F, E, R>)
 where
-    F: Serializer<Output = O> + Deserializer<I> + Clone,
-    E: Encoder<O> + Decoder<Item = I> + Clone,
+    F: Serializer + Deserializer<<E as Decoder>::Item> + Clone,
+    E: Encoder<<F as Serializer>::Output> + Decoder + Clone,
     W: AsyncWrite,
     R: AsyncRead,
 {


### PR DESCRIPTION
This removes an unnecessary lifetime parameter from UnboundedChan, and
changes the order of parameters in SymmetricalChan to match the order in
Chan.