### PR TITLE
Avoid running the drop glue for Chan/Branches every cast

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // File header
     writeln!(f, "#[allow(unused_imports)] use crate::prelude::*;")?;
     writeln!(f, "use static_assertions::assert_impl_all;")?;
-    writeln!(f, "")?;
+    writeln!(f)?;
 
     // Write out the test
     writeln!(f, "#[test]")?;
@@ -66,7 +66,7 @@ impl Session {
 impl Display for Session {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use Session::*;
-        Ok(match self {
+        match self {
             Done => write!(f, "Done")?,
             Recv(s) => write!(f, "Recv<(), {}>", s)?,
             Send(s) => write!(f, "Send<(), {}>", s)?,
@@ -107,7 +107,8 @@ impl Display for Session {
                     write!(f, "<_{}>", n)?;
                 }
             }
-        })
+        }
+        Ok(())
     }
 }
 
@@ -242,12 +243,10 @@ impl Session {
                 }
                 if cs.len() < max_width.into() {
                     cs.push(Done);
+                } else if loops > 0 && productive < loops {
+                    *self = Continue(productive);
                 } else {
-                    if loops > 0 && productive < loops {
-                        *self = Continue(productive);
-                    } else {
-                        return false;
-                    }
+                    return false;
                 }
             }
             Continue(n) => {

--- a/src/chan.rs
+++ b/src/chan.rs
@@ -4,7 +4,7 @@ use std::{
     any::TypeId,
     convert::TryInto,
     marker::{self, PhantomData},
-    mem,
+    mem::{self, ManuallyDrop},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
@@ -667,7 +667,7 @@ impl<Tx: marker::Send + 'static, Rx: marker::Send + 'static, S: Session> Chan<S,
         // We have to manually drop because the drop glue assumes `tx` and `rx` are present -- also,
         // it's more efficient because there's no reason to run the drop glue every time we execute
         // a cast (which this function is called in)!
-        drop(std::mem::ManuallyDrop::new(self));
+        let _ = ManuallyDrop::new(self);
         (tx, rx, drop_tx, drop_rx)
     }
 
@@ -844,7 +844,7 @@ where
         let drop_tx = self.drop_tx.clone();
         let drop_rx = self.drop_rx.clone();
         // We have to manually drop because the drop glue assumes tx and rx are present
-        drop(std::mem::ManuallyDrop::new(self));
+        let _ = ManuallyDrop::new(self);
         if variant == 0 {
             Ok(Chan {
                 tx,


### PR DESCRIPTION
Previously, the drop glue for both Chan and Branches would run at every
cast/case, doing nothing because at the point it was run, the struct had
been emptied out via Option::take()-ing its contents. This change
improves performance by avoiding running the drop glue at those moments.
It also improves performance for Split and Seq (or it should -- no
benchmarks for those exist yet) by avoiding a dynamic call to a boxed
function.

According to the current microbenchmarks (the more precise ones merged
in #27), this improves throughput for `send` by almost 20% and for `recv` by
almost 10%.