### PR TITLE
Implement the `Then` trait to support the macro compiler

### DIFF
--- a/dialectic/src/types/call.rs
+++ b/dialectic/src/types/call.rs
@@ -22,3 +22,11 @@ impl<N: Unary, P: Scoped<N>, Q: Scoped<N>> Scoped<N> for Call<P, Q> {}
 impl<N: Unary, P: Subst<R, N>, Q: Subst<R, N>, R> Subst<R, N> for Call<P, Q> {
     type Substituted = Call<P::Substituted, Q::Substituted>;
 }
+
+impl<N: Unary, P: Then<R, N>, Q: Then<R, N>, R> Then<R, N> for Call<P, Q> {
+    type Combined = Call<P::Combined, Q::Combined>;
+}
+
+impl<N: Unary, Level: Unary, P: Lift<N, Level>, Q: Lift<N, Level>> Lift<N, Level> for Call<P, Q> {
+    type Lifted = Call<P::Lifted, Q::Lifted>;
+}

--- a/dialectic/src/types/choose.rs
+++ b/dialectic/src/types/choose.rs
@@ -35,10 +35,26 @@ impl<N: Unary, Choices: Tuple + 'static> Scoped<N> for Choose<Choices> where
 impl<N: Unary, P, Choices> Subst<P, N> for Choose<Choices>
 where
     Choices: Tuple + 'static,
-    Choices::AsList: EachHasDual + EachSubst<P, N>,
-    <Choices::AsList as EachHasDual>::Duals: List + EachHasDual,
-    <Choices::AsList as EachSubst<P, N>>::Substituted: List + EachHasDual,
-    <<Choices::AsList as EachSubst<P, N>>::Substituted as EachHasDual>::Duals: List,
+    Choices::AsList: EachSubst<P, N>,
+    <Choices::AsList as EachSubst<P, N>>::Substituted: List,
 {
     type Substituted = Choose<<<Choices::AsList as EachSubst<P, N>>::Substituted as List>::AsTuple>;
+}
+
+impl<N: Unary, P, Choices> Then<P, N> for Choose<Choices>
+where
+    Choices: Tuple + 'static,
+    Choices::AsList: EachThen<P, N>,
+    <Choices::AsList as EachThen<P, N>>::Combined: List,
+{
+    type Combined = Choose<<<Choices::AsList as EachThen<P, N>>::Combined as List>::AsTuple>;
+}
+
+impl<N: Unary, Level: Unary, Choices> Lift<N, Level> for Choose<Choices>
+where
+    Choices: Tuple + 'static,
+    Choices::AsList: EachLift<N, Level>,
+    <Choices::AsList as EachLift<N, Level>>::Lifted: List,
+{
+    type Lifted = Choose<<<Choices::AsList as EachLift<N, Level>>::Lifted as List>::AsTuple>;
 }

--- a/dialectic/src/types/continue.rs
+++ b/dialectic/src/types/continue.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use super::sealed::IsSession;
 use super::*;
-use crate::unary::Compare;
+use crate::unary::{self, Compare};
 
 /// Repeat a [`Loop`]. The type-level index points to the loop to be repeated, counted from the
 /// innermost starting at [`Z`].
@@ -24,4 +24,24 @@ where
     <(N, M) as Compare<Continue<M>, P, Continue<M>>>::Result: 'static,
 {
     type Substituted = <(N, M) as Compare<Continue<M>, P, Continue<M>>>::Result;
+}
+
+impl<P, M: Unary, N: Unary> Then<P, N> for Continue<M> {
+    type Combined = Continue<M>;
+}
+
+impl<N: Unary, M: Unary, Level: Unary> Lift<N, Level> for Continue<M>
+where
+    (M, Level): Compare<
+        Continue<M>,
+        Continue<<(M, N) as unary::Add>::Result>,
+        Continue<<(M, N) as unary::Add>::Result>,
+    >,
+    (M, N): unary::Add,
+{
+    type Lifted = <(M, Level) as Compare<
+        Continue<M>,
+        Continue<<(M, N) as unary::Add>::Result>,
+        Continue<<(M, N) as unary::Add>::Result>,
+    >>::Result;
 }

--- a/dialectic/src/types/done.rs
+++ b/dialectic/src/types/done.rs
@@ -22,6 +22,17 @@ impl<P, N: Unary> Subst<P, N> for Done {
     type Substituted = Done;
 }
 
+impl<P, N: Unary> Then<P, N> for Done
+where
+    P: Lift<N>,
+{
+    type Combined = P::Lifted;
+}
+
+impl<N: Unary, Level: Unary> Lift<N, Level> for Done {
+    type Lifted = Done;
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(unused)]

--- a/dialectic/src/types/loop.rs
+++ b/dialectic/src/types/loop.rs
@@ -28,7 +28,20 @@ where
 impl<P, Q, N: Unary> Subst<Q, N> for Loop<P>
 where
     P: Subst<Q, S<N>>,
-    <P as Subst<Q, S<N>>>::Substituted: HasDual,
 {
     type Substituted = Loop<<P as Subst<Q, S<N>>>::Substituted>;
+}
+
+impl<P, Q, N: Unary> Then<Q, N> for Loop<P>
+where
+    P: Then<Q, S<N>>,
+{
+    type Combined = Loop<<P as Then<Q, S<N>>>::Combined>;
+}
+
+impl<N: Unary, Level: Unary, P> Lift<N, Level> for Loop<P>
+where
+    P: Lift<N, S<Level>>,
+{
+    type Lifted = Loop<<P as Lift<N, S<Level>>>::Lifted>;
 }

--- a/dialectic/src/types/offer.rs
+++ b/dialectic/src/types/offer.rs
@@ -34,10 +34,26 @@ impl<N: Unary, Choices: Tuple + 'static> Scoped<N> for Offer<Choices> where
 impl<N: Unary, P, Choices> Subst<P, N> for Offer<Choices>
 where
     Choices: Tuple + 'static,
-    Choices::AsList: EachHasDual + EachSubst<P, N>,
-    <Choices::AsList as EachHasDual>::Duals: List + EachHasDual,
-    <Choices::AsList as EachSubst<P, N>>::Substituted: List + EachHasDual,
-    <<Choices::AsList as EachSubst<P, N>>::Substituted as EachHasDual>::Duals: List,
+    Choices::AsList: EachSubst<P, N>,
+    <Choices::AsList as EachSubst<P, N>>::Substituted: List,
 {
     type Substituted = Offer<<<Choices::AsList as EachSubst<P, N>>::Substituted as List>::AsTuple>;
+}
+
+impl<N: Unary, P, Choices> Then<P, N> for Offer<Choices>
+where
+    Choices: Tuple + 'static,
+    Choices::AsList: EachThen<P, N>,
+    <Choices::AsList as EachThen<P, N>>::Combined: List,
+{
+    type Combined = Offer<<<Choices::AsList as EachThen<P, N>>::Combined as List>::AsTuple>;
+}
+
+impl<N: Unary, Level: Unary, Choices> Lift<N, Level> for Offer<Choices>
+where
+    Choices: Tuple + 'static,
+    Choices::AsList: EachLift<N, Level>,
+    <Choices::AsList as EachLift<N, Level>>::Lifted: List,
+{
+    type Lifted = Offer<<<Choices::AsList as EachLift<N, Level>>::Lifted as List>::AsTuple>;
 }

--- a/dialectic/src/types/recv.rs
+++ b/dialectic/src/types/recv.rs
@@ -23,3 +23,11 @@ impl<T: 'static, N: Unary, P: Scoped<N>> Scoped<N> for Recv<T, P> {}
 impl<N: Unary, T: 'static, P: Subst<Q, N>, Q> Subst<Q, N> for Recv<T, P> {
     type Substituted = Recv<T, P::Substituted>;
 }
+
+impl<N: Unary, T: 'static, P: Then<Q, N>, Q> Then<Q, N> for Recv<T, P> {
+    type Combined = Recv<T, P::Combined>;
+}
+
+impl<N: Unary, T: 'static, P: Lift<N, Level>, Level: Unary> Lift<N, Level> for Recv<T, P> {
+    type Lifted = Recv<T, P::Lifted>;
+}

--- a/dialectic/src/types/send.rs
+++ b/dialectic/src/types/send.rs
@@ -23,3 +23,11 @@ impl<T: 'static, N: Unary, P: Scoped<N>> Scoped<N> for Send<T, P> {}
 impl<N: Unary, T: 'static, P: Subst<Q, N>, Q> Subst<Q, N> for Send<T, P> {
     type Substituted = Send<T, P::Substituted>;
 }
+
+impl<N: Unary, T: 'static, P: Then<Q, N>, Q> Then<Q, N> for Send<T, P> {
+    type Combined = Send<T, P::Combined>;
+}
+
+impl<N: Unary, T: 'static, P: Lift<N, Level>, Level: Unary> Lift<N, Level> for Send<T, P> {
+    type Lifted = Send<T, P::Lifted>;
+}

--- a/dialectic/src/types/split.rs
+++ b/dialectic/src/types/split.rs
@@ -26,3 +26,11 @@ impl<N: Unary, P: Scoped<N>, Q: Scoped<N>> Scoped<N> for Split<P, Q> {}
 impl<N: Unary, P: Subst<R, N>, Q: Subst<R, N>, R> Subst<R, N> for Split<P, Q> {
     type Substituted = Split<P::Substituted, Q::Substituted>;
 }
+
+impl<N: Unary, P: Then<R, N>, Q: Then<R, N>, R> Then<R, N> for Split<P, Q> {
+    type Combined = Split<P::Combined, Q::Combined>;
+}
+
+impl<N: Unary, Level: Unary, P: Lift<N, Level>, Q: Lift<N, Level>> Lift<N, Level> for Split<P, Q> {
+    type Lifted = Split<P::Lifted, Q::Lifted>;
+}


### PR DESCRIPTION
Fixes #32. This also eliminates unnecessary bounds left over from
previous iterations of the type system.