### PR TITLE
Fix proc macros so that they work in all crate/test locations

### DIFF
--- a/dialectic-compiler/Cargo.toml
+++ b/dialectic-compiler/Cargo.toml
@@ -12,8 +12,7 @@ thunderdome = "0.4.0"
 syn = { version = "1.0.60", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0.24"
 quote = "1.0.9"
-proc-macro-crate = "0.1.5"
-lazy_static = "1.4.0"
+proc-macro-crate = "1.0.0"
 thiserror = "1.0.23"
 quickcheck = { version = "1.0.3", optional = true }
 

--- a/dialectic-compiler/src/target.rs
+++ b/dialectic-compiler/src/target.rs
@@ -2,9 +2,9 @@
 
 use {
     proc_macro2::TokenStream,
-    quote::{format_ident, quote_spanned, ToTokens},
-    std::{env, fmt, rc::Rc},
-    syn::{parse_quote, Path, Type},
+    quote::{quote_spanned, ToTokens},
+    std::{fmt, rc::Rc},
+    syn::{Path, Type},
 };
 
 use crate::Spanned;
@@ -190,34 +190,6 @@ impl Spanned<Target> {
 
 impl ToTokens for Spanned<Target> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        use proc_macro_crate::FoundCrate;
-
-        // We need to find the right path where we can reference types in our proc macro. This is a
-        // little tricky. There are three cases to consider.
-        let dialectic_crate: Path = match proc_macro_crate::crate_name("dialectic") {
-            // The first case is that we are in dialectic and compiling dialectic itself, OR we are
-            // compiling a dialectic doctest. In this case, we want to use `crate::dialectic`, which
-            // will grab the symbol "dialectic" in the crate root. In the case of a doctest, this
-            // will result in the extern crate dialectic; in the case of dialectic itself, it will
-            // result in a private dummy module called "dialectic", which exists to support macro
-            // calls like these and re-exports dialectic::types.
-            Ok(FoundCrate::Itself)
-                if env::var("CARGO_CRATE_NAME").as_deref() == Ok("dialectic") =>
-            {
-                parse_quote!(crate::dialectic)
-            }
-            // The second case is that we are in an integration test of dialectic. This one's
-            // straightforward.
-            Ok(FoundCrate::Itself) | Err(_) => parse_quote!(::dialectic),
-            // And lastly, the third case: we are in a user's crate. We found the crate with the
-            // name `dialectic` and will use that identifier as our crate name, in a similar manner
-            // to the second case, prefixed with `::` to ensure it is a "global" path.
-            Ok(FoundCrate::Name(name)) => {
-                let name_ident = format_ident!("{}", name);
-                parse_quote!(::#name_ident)
-            }
-        };
-
-        self.to_tokens_with_crate_name(&dialectic_crate, tokens);
+        self.to_tokens_with_crate_name(&crate::dialectic_path(), tokens);
     }
 }

--- a/dialectic-compiler/src/target.rs
+++ b/dialectic-compiler/src/target.rs
@@ -1,11 +1,10 @@
 //! The target language of the `Session!` macro, produced by the compiler.
 
 use {
-    lazy_static::lazy_static,
     proc_macro2::TokenStream,
-    quote::{quote_spanned, ToTokens},
-    std::{fmt, rc::Rc},
-    syn::{Ident, Type},
+    quote::{format_ident, quote_spanned, ToTokens},
+    std::{env, fmt, rc::Rc},
+    syn::{parse_quote, Path, Type},
 };
 
 use crate::Spanned;
@@ -105,47 +104,69 @@ impl fmt::Display for Target {
     }
 }
 
-impl ToTokens for Spanned<Target> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        use Target::*;
+impl Spanned<Target> {
+    /// Convert this `Spanned<Target>` into a `TokenStream` using a provided crate name when
+    /// referencing types from dialectic.
+    pub fn to_token_stream_with_crate_name(&self, dialectic_crate: &Path) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        self.to_tokens_with_crate_name(dialectic_crate, &mut tokens);
+        tokens
+    }
 
-        lazy_static! {
-            static ref CRATE_NAME: String = proc_macro_crate::crate_name("dialectic")
-                .unwrap_or_else(|_| "dialectic".to_owned());
-        }
+    /// Convert this `Spanned<Target>` into tokens and append them to the provided `TokenStream`
+    /// using a provided crate name when referencing types from dialectic.
+    pub fn to_tokens_with_crate_name(&self, dialectic_crate: &Path, tokens: &mut TokenStream) {
+        use Target::*;
 
         // We assign the associated span of the target to any type tokens generated, in an attempt
         // to get at least some type errors/issues to show up in the right place.
         let span = self.span;
-        let dialectic_crate = Ident::new(&**CRATE_NAME, span);
 
         match &self.inner {
             Done => quote_spanned! {span=> #dialectic_crate::types::Done }.to_tokens(tokens),
             Recv(t, s) => {
-                quote_spanned!(span=> #dialectic_crate::types::Recv<#t, #s>).to_tokens(tokens)
+                let s = s.to_token_stream_with_crate_name(dialectic_crate);
+                quote_spanned!(span=> #dialectic_crate::types::Recv<#t, #s>).to_tokens(tokens);
             }
             Send(t, s) => {
-                quote_spanned!(span=> #dialectic_crate::types::Send<#t, #s>).to_tokens(tokens)
+                let s = s.to_token_stream_with_crate_name(dialectic_crate);
+                quote_spanned!(span=> #dialectic_crate::types::Send<#t, #s>).to_tokens(tokens);
             }
-            Loop(s) => quote_spanned!(span=> #dialectic_crate::types::Loop<#s>).to_tokens(tokens),
+            Loop(s) => {
+                let s = s.to_token_stream_with_crate_name(dialectic_crate);
+                quote_spanned!(span=> #dialectic_crate::types::Loop<#s>).to_tokens(tokens);
+            }
             Split {
                 tx_only: s,
                 rx_only: p,
                 cont: q,
             } => {
-                quote_spanned!(span=> #dialectic_crate::types::Split<#s, #p, #q>).to_tokens(tokens)
+                let s = s.to_token_stream_with_crate_name(dialectic_crate);
+                let p = p.to_token_stream_with_crate_name(dialectic_crate);
+                let q = q.to_token_stream_with_crate_name(dialectic_crate);
+                quote_spanned!(span=> #dialectic_crate::types::Split<#s, #p, #q>).to_tokens(tokens);
             }
             Call(s, p) => {
-                quote_spanned!(span=> #dialectic_crate::types::Call<#s, #p>).to_tokens(tokens)
+                let s = s.to_token_stream_with_crate_name(dialectic_crate);
+                let p = p.to_token_stream_with_crate_name(dialectic_crate);
+                quote_spanned!(span=> #dialectic_crate::types::Call<#s, #p>).to_tokens(tokens);
             }
             Then(s, p) => {
+                let s = s.to_token_stream_with_crate_name(dialectic_crate);
+                let p = p.to_token_stream_with_crate_name(dialectic_crate);
                 quote_spanned!(span=> <#s as #dialectic_crate::types::Then<#p>>::Combined)
-                    .to_tokens(tokens)
+                    .to_tokens(tokens);
             }
             Choose(cs) => {
+                let cs = cs
+                    .iter()
+                    .map(|c| c.to_token_stream_with_crate_name(dialectic_crate));
                 quote_spanned!(span=> #dialectic_crate::types::Choose<(#(#cs,)*)>).to_tokens(tokens)
             }
             Offer(cs) => {
+                let cs = cs
+                    .iter()
+                    .map(|c| c.to_token_stream_with_crate_name(dialectic_crate));
                 quote_spanned!(span=> #dialectic_crate::types::Offer<(#(#cs,)*)>).to_tokens(tokens)
             }
             Continue(n) => {
@@ -164,5 +185,39 @@ impl ToTokens for Spanned<Target> {
             }
             Type(s) => quote_spanned!(span=> #s).to_tokens(tokens),
         }
+    }
+}
+
+impl ToTokens for Spanned<Target> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use proc_macro_crate::FoundCrate;
+
+        // We need to find the right path where we can reference types in our proc macro. This is a
+        // little tricky. There are three cases to consider.
+        let dialectic_crate: Path = match proc_macro_crate::crate_name("dialectic") {
+            // The first case is that we are in dialectic and compiling dialectic itself, OR we are
+            // compiling a dialectic doctest. In this case, we want to use `crate::dialectic`, which
+            // will grab the symbol "dialectic" in the crate root. In the case of a doctest, this
+            // will result in the extern crate dialectic; in the case of dialectic itself, it will
+            // result in a private dummy module called "dialectic", which exists to support macro
+            // calls like these and re-exports dialectic::types.
+            Ok(FoundCrate::Itself)
+                if env::var("CARGO_CRATE_NAME").as_deref() == Ok("dialectic") =>
+            {
+                parse_quote!(crate::dialectic)
+            }
+            // The second case is that we are in an integration test of dialectic. This one's
+            // straightforward.
+            Ok(FoundCrate::Itself) | Err(_) => parse_quote!(::dialectic),
+            // And lastly, the third case: we are in a user's crate. We found the crate with the
+            // name `dialectic` and will use that identifier as our crate name, in a similar manner
+            // to the second case, prefixed with `::` to ensure it is a "global" path.
+            Ok(FoundCrate::Name(name)) => {
+                let name_ident = format_ident!("{}", name);
+                parse_quote!(::#name_ident)
+            }
+        };
+
+        self.to_tokens_with_crate_name(&dialectic_crate, tokens);
     }
 }

--- a/dialectic-compiler/tests/tally_client.rs
+++ b/dialectic-compiler/tests/tally_client.rs
@@ -119,15 +119,15 @@ fn tally_client_direct_subst_nested_loop_break() {
     .unwrap();
 
     let rhs: Type = syn::parse_str(
-            "dialectic::types::Loop<
-                dialectic::types::Choose<(
-                    dialectic::types::Done,
-                    dialectic::types::Send<
+            "::dialectic::types::Loop<
+                ::dialectic::types::Choose<(
+                    ::dialectic::types::Done,
+                    ::dialectic::types::Send<
                         Operation,
-                        dialectic::types::Loop<
-                            dialectic::types::Choose<(
-                                dialectic::types::Send<i64, dialectic::types::Continue>,
-                                dialectic::types::Recv<i64, dialectic::types::Continue<dialectic::unary::S<dialectic::unary::Z>>>,
+                        ::dialectic::types::Loop<
+                            ::dialectic::types::Choose<(
+                                ::dialectic::types::Send<i64, ::dialectic::types::Continue>,
+                                ::dialectic::types::Recv<i64, ::dialectic::types::Continue<::dialectic::unary::S<::dialectic::unary::Z>>>,
                             )>
                         >
                     >,

--- a/dialectic-macro/Cargo.toml
+++ b/dialectic-macro/Cargo.toml
@@ -12,7 +12,6 @@ dialectic-compiler = { path = "../dialectic-compiler" }
 syn = { version = "1.0", features = ["full", "parsing"] }
 proc-macro2 = "1.0"
 quote = "1.0"
-proc-macro-crate = "1.0.0"
 
 [dev-dependencies]
 dialectic = { path = "../dialectic" }

--- a/dialectic-macro/Cargo.toml
+++ b/dialectic-macro/Cargo.toml
@@ -12,8 +12,7 @@ dialectic-compiler = { path = "../dialectic-compiler" }
 syn = { version = "1.0", features = ["full", "parsing"] }
 proc-macro2 = "1.0"
 quote = "1.0"
-proc-macro-crate = "0.1.5"
-lazy_static = "1.4.0"
+proc-macro-crate = "1.0.0"
 
 [dev-dependencies]
 dialectic = { path = "../dialectic" }

--- a/dialectic-macro/src/lib.rs
+++ b/dialectic-macro/src/lib.rs
@@ -246,26 +246,6 @@ pub fn Session(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     }
 }
 
-// /// Special version of the `Session!` macro which always outputs `crate` as the root of its paths,
-// /// for use internally with dialectic.
-// #[proc_macro]
-// #[allow(non_snake_case)]
-// #[doc(hidden)]
-// pub fn SessionInternal(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-//     let result = parse_macro_input!(input as dialectic_compiler::Invocation).compile();
-
-//     match result {
-//         Ok(compiled) => compiled
-//             .to_token_stream_with_crate_name()
-//             .into(),
-//         Err(error) => {
-//             let compile_errors = error.to_compile_error();
-//             let quoted = quote! { [(); { #compile_errors 0 }] };
-//             quoted.into()
-//         }
-//     }
-// }
-
 /// The `offer!` macro offers a set of different protocols, allowing the other side of the channel
 /// to choose with which one to proceed.
 ///

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -109,6 +109,15 @@ use backend::*;
 #[allow(unused_imports)] // For documentation linking
 use prelude::*;
 
+/// This is a dummy module for the offer/Session proc macros to refer to from within dialectic to
+/// ensure that the same path can resolve to the same types in different scopes (the scope of being
+/// inside the dialectic crate somewhere and the scope of being inside a doctest being compiled
+/// within dialectic, which *looks* like the dialectic crate itself to any proc macro but actually
+/// isn't and has the dialectic crate as an extern crate in scope.)
+pub(crate) mod dialectic {
+    pub use crate::*;
+}
+
 /// The prelude module for quickly getting started with Dialectic.
 ///
 /// This module is designed to be imported as `use dialectic::prelude::*;`, which brings into scope

--- a/dialectic/src/types/done.rs
+++ b/dialectic/src/types/done.rs
@@ -42,7 +42,15 @@ mod tests {
     fn done_in_seq() {
         use crate::prelude::*;
 
-        type S = Loop<Call<Send<String, Done>, Recv<String, Done>>>;
+        type S = Session! {
+            loop {
+                call {
+                    send String;
+                }
+                recv String;
+                break;
+            }
+        };
 
         async fn serve<Tx, Rx>(chan: Chan<S, Tx, Rx>) -> Result<(), Box<dyn std::error::Error>>
         where


### PR DESCRIPTION
Allows offer! and Session! to be used in all locations including inside doctests in dialectic, integration testts, unit tests, and within the dialectic crate itself.