### PR TITLE
Benchmark against the null backend

### DIFF
--- a/dialectic/Cargo.toml
+++ b/dialectic/Cargo.toml
@@ -58,6 +58,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 name = "mpsc"
 harness = false
 
+[[bench]]
+name = "micro"
+harness = false
+
 [[example]]
 name = "common"
 required-features = ["bincode"]

--- a/dialectic/benches/micro.rs
+++ b/dialectic/benches/micro.rs
@@ -41,8 +41,8 @@ where
 }
 
 async fn choose<Tx, Rx>(
-    chan: Chan<Session! { loop { choose { _0 => continue } } }, Tx, Rx>,
-) -> Chan<Session! { loop { choose { _0 => continue } } }, Tx, Rx>
+    chan: Chan<Session! { loop { choose { _0 => {} } } }, Tx, Rx>,
+) -> Chan<Session! { loop { choose { _0 => {} } } }, Tx, Rx>
 where
     Tx: Transmit<Choice<_1>, Val> + marker::Send,
     Tx::Error: Debug,
@@ -52,8 +52,8 @@ where
 }
 
 async fn offer<Tx, Rx>(
-    chan: Chan<Session! { loop { offer { _0 => continue } } }, Tx, Rx>,
-) -> Chan<Session! { loop { offer { _0 => continue } } }, Tx, Rx>
+    chan: Chan<Session! { loop { offer { _0 => {} } } }, Tx, Rx>,
+) -> Chan<Session! { loop { offer { _0 => {} } } }, Tx, Rx>
 where
     Tx: marker::Send,
     Rx: Receive<Choice<_1>> + marker::Send,

--- a/dialectic/benches/micro.rs
+++ b/dialectic/benches/micro.rs
@@ -1,0 +1,213 @@
+use criterion::{
+    async_executor::AsyncExecutor, criterion_group, criterion_main, measurement::WallTime, Bencher,
+    BenchmarkGroup, Criterion,
+};
+use dialectic::backend::{mpsc, null};
+use dialectic::prelude::*;
+use futures::Future;
+use std::{convert::TryInto, fmt::Debug, marker, sync::Arc, time::Instant};
+use tokio::runtime::Runtime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum Primitive {
+    Send,
+    Recv,
+    Choose,
+    Offer,
+    Call,
+    Split,
+}
+
+async fn send<Tx, Rx>(
+    chan: Chan<Session! { loop { send () } }, Tx, Rx>,
+) -> Chan<Session! { loop { send () } }, Tx, Rx>
+where
+    Tx: Transmit<(), Val> + marker::Send,
+    Tx::Error: Debug,
+    Rx: marker::Send,
+{
+    chan.send(()).await.unwrap()
+}
+
+async fn recv<Tx, Rx>(
+    chan: Chan<Session! { loop { recv () } }, Tx, Rx>,
+) -> Chan<Session! { loop { recv () } }, Tx, Rx>
+where
+    Tx: marker::Send,
+    Rx: Receive<()> + marker::Send,
+    Rx::Error: Debug,
+{
+    chan.recv().await.unwrap().1
+}
+
+async fn choose<Tx, Rx>(
+    chan: Chan<Session! { loop { choose { _0 => continue } } }, Tx, Rx>,
+) -> Chan<Session! { loop { choose { _0 => continue } } }, Tx, Rx>
+where
+    Tx: Transmit<Choice<_1>, Val> + marker::Send,
+    Tx::Error: Debug,
+    Rx: marker::Send,
+{
+    chan.choose(_0).await.unwrap()
+}
+
+async fn offer<Tx, Rx>(
+    chan: Chan<Session! { loop { offer { _0 => continue } } }, Tx, Rx>,
+) -> Chan<Session! { loop { offer { _0 => continue } } }, Tx, Rx>
+where
+    Tx: marker::Send,
+    Rx: Receive<Choice<_1>> + marker::Send,
+    Rx::Error: Debug,
+{
+    offer!(chan => {
+        _0 => chan,
+    })
+    .unwrap()
+}
+
+async fn call<Tx, Rx>(
+    chan: Chan<Session! { loop { call {} } }, Tx, Rx>,
+) -> Chan<Session! { loop { call {} } }, Tx, Rx>
+where
+    Tx: marker::Send,
+    Rx: marker::Send,
+{
+    chan.call(|_| async { Ok::<_, ()>(()) })
+        .await
+        .unwrap()
+        .1
+        .unwrap()
+}
+
+async fn split<Tx, Rx>(
+    chan: Chan<Session! { loop { split { -> {}, <- {} } } }, Tx, Rx>,
+) -> Chan<Session! { loop { split { -> {} <- {} } } }, Tx, Rx>
+where
+    Tx: marker::Send,
+    Rx: marker::Send,
+{
+    chan.split(|_, _| async { Ok::<_, ()>(()) })
+        .await
+        .unwrap()
+        .1
+        .unwrap()
+}
+
+fn bench_chan_loop<S, Tx, Rx, F, Fut, N, H, A>(
+    b: &mut Bencher,
+    rt: Arc<A>,
+    channel: N,
+    primitive: Primitive,
+    f: F,
+) where
+    F: Fn(Chan<S, Tx, Rx>) -> Fut,
+    Fut: Future<Output = Chan<S, Tx, Rx>>,
+    N: Fn(Primitive, u64) -> (Tx, Rx, H),
+    S: Session,
+    Tx: marker::Send + 'static,
+    Rx: marker::Send + 'static,
+    A: AsyncExecutor,
+{
+    b.iter_custom(|iters| {
+        let (tx, rx, drop_after_bench) = channel(primitive, iters);
+        let mut chan = S::wrap(tx, rx);
+        let elapsed = rt.block_on(async {
+            let start = Instant::now();
+            for _ in 0..iters {
+                chan = f(chan).await;
+            }
+            start.elapsed()
+        });
+        drop(drop_after_bench);
+        elapsed
+    });
+}
+
+fn bench_chan_loop_group<S, Tx, Rx, Fut, H, A>(
+    g: &mut BenchmarkGroup<WallTime>,
+    rt: Arc<A>,
+    channel: fn(Primitive, u64) -> (Tx, Rx, H),
+    name: &str,
+    primitive: Primitive,
+    f: fn(Chan<S, Tx, Rx>) -> Fut,
+) where
+    Fut: Future<Output = Chan<S, Tx, Rx>>,
+    S: Session,
+    Tx: marker::Send + 'static,
+    Rx: marker::Send + 'static,
+    A: AsyncExecutor,
+{
+    g.bench_function(name, move |b| {
+        bench_chan_loop(b, rt.clone(), channel, primitive, f)
+    });
+}
+
+fn bench_all_on<Tx, Rx, H, A>(
+    c: &mut Criterion,
+    rt_name: &str,
+    rt: Arc<A>,
+    backend_name: &str,
+    channel: fn(Primitive, u64) -> (Tx, Rx, H),
+) where
+    Tx: Transmit<(), Val> + Transmit<Choice<_1>, Val> + marker::Send + 'static,
+    <Tx as Transmit<(), Val>>::Error: Debug,
+    <Tx as Transmit<Choice<_1>, Val>>::Error: Debug,
+    Rx: Receive<()> + Receive<Choice<_1>> + marker::Send + 'static,
+    <Rx as Receive<()>>::Error: Debug,
+    <Rx as Receive<Choice<_1>>>::Error: Debug,
+    A: AsyncExecutor,
+{
+    use Primitive::*;
+    let group_name = format!("{}/{}", rt_name, backend_name);
+    let mut g = c.benchmark_group(&group_name);
+    bench_chan_loop_group(&mut g, rt.clone(), channel, "send", Send, send);
+    bench_chan_loop_group(&mut g, rt.clone(), channel, "recv", Recv, recv);
+    bench_chan_loop_group(&mut g, rt.clone(), channel, "choose", Choose, choose);
+    bench_chan_loop_group(&mut g, rt.clone(), channel, "offer", Offer, offer);
+    bench_chan_loop_group(&mut g, rt.clone(), channel, "call", Call, call);
+    bench_chan_loop_group(&mut g, rt, channel, "split", Split, split);
+    g.finish();
+}
+
+fn bench_tokio_null(c: &mut Criterion) {
+    bench_all_on(
+        c,
+        "tokio",
+        Arc::new(Runtime::new().unwrap()),
+        "null",
+        |_primitive, _iters| (null::Sender::default(), null::Receiver::default(), ()),
+    )
+}
+
+fn bench_tokio_mpsc(c: &mut Criterion) {
+    use Primitive::*;
+    bench_all_on(
+        c,
+        "tokio",
+        Arc::new(Runtime::new().unwrap()),
+        "mpsc",
+        |primitive, iters| {
+            let (tx0, rx0) = mpsc::unbounded_channel();
+            let (tx1, rx1) = mpsc::unbounded_channel();
+            // Pre-allocate responses for those operations which need responses
+            match primitive {
+                Send | Choose | Call | Split => {}
+                Recv => {
+                    for _ in 0..iters {
+                        tx1.send(Box::new(())).unwrap();
+                    }
+                }
+                Offer => {
+                    for _ in 0..iters {
+                        let zero_choice: Choice<_1> = 0u8.try_into().unwrap();
+                        tx1.send(Box::new(zero_choice)).unwrap();
+                    }
+                }
+            };
+            (tx0, rx1, (tx1, rx0))
+        },
+    )
+}
+
+criterion_group!(benches, bench_tokio_null, bench_tokio_mpsc);
+criterion_main!(benches);

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -27,6 +27,8 @@ pub mod mpsc;
 #[cfg(feature = "serde")]
 pub mod serde;
 
+pub mod null;
+
 /// If a transport is `Transmit<T, Convention>`, we can use it to [`send`](Transmit::send) a message
 /// of type `T` by [`Val`], [`Ref`], or [`Mut`], depending on the calling convention specified.
 ///

--- a/dialectic/src/backend/null.rs
+++ b/dialectic/src/backend/null.rs
@@ -3,7 +3,8 @@
 //! This backend is useful primarily only for benchmarking, as it does the absolute minimum amount
 //! of work, so that it is easier to isolate performance issues in Dialectic itself. You cannot
 //! implement most protocols using this backend, as it is limited to transporting the unit type `()`
-//! and cannot [`choose`](Chan::choose) or [`offer!`](crate::offer) more than a single choice.
+//! and cannot [`choose`](crate::Chan::choose) or [`offer!`](crate::offer) more than a single
+//! choice.
 
 use crate::backend::*;
 use crate::unary::{Unary, S, Z};

--- a/dialectic/src/backend/null.rs
+++ b/dialectic/src/backend/null.rs
@@ -1,0 +1,111 @@
+//! A "null" backend implementation which can only send and receive the unit type `()`.
+//!
+//! This backend is useful primarily only for benchmarking, as it does the absolute minimum amount
+//! of work, so that it is easier to isolate performance issues in Dialectic itself. You cannot
+//! implement most protocols using this backend, as it is limited to transporting the unit type `()`
+//! and cannot [`choose`](Chan::choose) or [`offer!`](crate::offer) more than a single choice.
+
+use crate::backend::*;
+use crate::unary::{Unary, S, Z};
+use std::{convert::TryInto, future::Future, pin::Pin};
+
+/// Shorthand for a [`Chan`](crate::Chan) using a [`null`](crate::backend::null) [`Sender`] and
+/// [`Receiver`].
+///
+/// # Examples
+///
+/// ```
+/// use dialectic::prelude::*;
+/// use dialectic::backend::null;
+/// use dialectic::types::Done;
+///
+/// let _: (null::Chan<Done>, null::Chan<Done>) =
+///     Done::channel(null::channel);
+/// ```
+pub type Chan<P> = crate::Chan<P, Sender, Receiver>;
+
+/// A receiver only capable of receiving the unit type `()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Receiver {
+    _private: (),
+}
+
+/// A sender only capable of sending the unit type `()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Sender {
+    _private: (),
+}
+
+/// Create a channel for transporting unit values `()` only.
+///
+/// # Examples
+///
+/// ```
+/// let (tx, rx) = dialectic::backend::null::channel();
+/// ```
+pub fn channel() -> (Sender, Receiver) {
+    (Sender::default(), Receiver::default())
+}
+
+/// An error thrown while receiving from or sending to a [`null`](crate::backend::null) channel.
+///
+/// No such errors are possible, so this type cannot be constructed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Transmit<(), Val> for Sender {
+    type Error = Error;
+
+    fn send<'a, 'async_lifetime>(
+        &'async_lifetime mut self,
+        _message: <() as CallBy<Val>>::Type,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
+    where
+        'a: 'async_lifetime,
+    {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+impl Receive<()> for Receiver {
+    type Error = Error;
+
+    fn recv<'async_lifetime>(
+        &'async_lifetime mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+impl Transmit<Choice<S<Z>>, Val> for Sender {
+    type Error = Error;
+
+    fn send<'a, 'async_lifetime>(
+        &'async_lifetime mut self,
+        _message: <Choice<S<Z>> as CallBy<Val>>::Type,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
+    where
+        'a: 'async_lifetime,
+    {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+impl<N: Unary> Receive<Choice<S<N>>> for Receiver {
+    type Error = Error;
+
+    fn recv<'async_lifetime>(
+        &'async_lifetime mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Choice<S<N>>, Self::Error>> + Send + 'async_lifetime>>
+    {
+        Box::pin(async { Ok((N::VALUE as u8).try_into().unwrap()) })
+    }
+}


### PR DESCRIPTION
This PR implements a new set of benchmarks that compare microbenchmarks between `tokio::sync::mpsc` and the null backend (also implemented in this PR), which does the least amount of work possible. It is organized in such a way as to enable easy extension to more backends in the future, and should eventually supersede the set of benchmarks in `mpsc.rs`.