### PR TITLE
Fixes #51 by removing unnecessary replicated feature flags

### DIFF
--- a/dialectic/Cargo.toml
+++ b/dialectic/Cargo.toml
@@ -17,11 +17,6 @@ mpsc = ["tokio/sync"]
 serde = ["tokio/io-util", "tokio-util/codec", "serde-crate"]
 bincode = ["serde", "bincode-crate", "bytes"]
 json = ["serde", "serde_json"]
-json_arbitrary_precision = [ "json", "serde_json/arbitrary_precision" ]
-json_float_roundtrip = [ "json", "serde_json/float_roundtrip" ]
-json_preserve_order = [ "json", "serde_json/preserve_order" ]
-json_raw_value = [ "json", "serde_json/raw_value" ]
-json_unbounded_depth = [ "json", "serde_json/unbounded_depth" ]
 
 [dependencies]
 thiserror = "1"


### PR DESCRIPTION
Users can specify the flags of the underlying library in their own Cargo.toml.