### PR TITLE
Backend refactor 2

### DIFF
--- a/dialectic-macro/src/lib.rs
+++ b/dialectic-macro/src/lib.rs
@@ -461,9 +461,9 @@ impl ToTokens for Mutability {
         use Mutability::*;
         let dialectic_path = dialectic_compiler::dialectic_path();
         stream.extend(match self {
-            Val(t) => quote_spanned!(t.span()=> #dialectic_path::call_by::Val),
-            Ref(t) => quote_spanned!(t.span()=> #dialectic_path::call_by::Ref),
-            Mut(t) => quote_spanned!(t.span()=> #dialectic_path::call_by::Mut),
+            Val(t) => quote_spanned!(t.span()=> #dialectic_path::backend::Val),
+            Ref(t) => quote_spanned!(t.span()=> #dialectic_path::backend::Ref),
+            Mut(t) => quote_spanned!(t.span()=> #dialectic_path::backend::Mut),
         })
     }
 }

--- a/dialectic-macro/src/lib.rs
+++ b/dialectic-macro/src/lib.rs
@@ -661,18 +661,6 @@ fn where_predicates_mut(
 ///     Tx: Transmit<T1>,
 ///     Tx: Transmit<T2>,
 ///     // ...
-///     // For each `N` from 0 to 255:
-///     Tx: Transmit<Choice<0>>,
-///     // ...
-///     Tx: Transmit<Choice<255>>,
-///     // For each `N` from 0 to 255:
-///     for<'a> Choice<0>: By<'a, Tx::Convention>
-///         + Convert<'a, Mut, Tx::Convention>
-///         + By<'a, Mut, Type = &'a mut Choice<0>>,
-///     // ...
-///     for<'a> Choice<255>: By<'a, Tx::Convention>
-///         + Convert<'a, Mut, Tx::Convention>
-///         + By<'a, Mut, Type = &'a mut Choice<255>>,
 /// {}
 /// ```
 #[allow(non_snake_case)]
@@ -705,17 +693,6 @@ pub fn Transmitter(
         for ty in types {
             predicates.push(syn::parse_quote! {
                 #name: #dialectic_path::backend::Transmit<#ty>
-            });
-        }
-        for n in 0usize..255 {
-            predicates.push(syn::parse_quote! {
-                #name: #dialectic_path::backend::Transmit<dialectic::backend::Choice<#n>>
-            });
-            predicates.push(syn::parse_quote! {
-                for<'a> #dialectic_path::backend::Choice<#n>:
-                    #dialectic_path::call_by::By<'a, <#name as dialectic::backend::Transmitter>::Convention>
-                    + #dialectic_path::call_by::Convert<'a, #dialectic_path::call_by::Mut, <#name as dialectic::backend::Transmitter>::Convention>
-                    + #dialectic_path::call_by::By<'a, #dialectic_path::call_by::Mut, Type = &'a mut Choice<#n>>
             });
         }
         item.into_token_stream().into()
@@ -800,10 +777,6 @@ pub fn Transmitter(
 ///     Rx: Receive<T1>,
 ///     Rx: Receive<T2>,
 ///     // ...
-///     // For each `N` from 0 to 255:
-///     Rx: Receive<Choice<0>>,
-///     // ...
-///     Rx: Receive<Choice<255>>,
 /// {}
 /// ```
 #[allow(non_snake_case)]
@@ -824,11 +797,6 @@ pub fn Receiver(
         for ty in types {
             predicates.push(syn::parse_quote! {
                 #name: #dialectic_path::backend::Receive<#ty>
-            });
-        }
-        for n in 0usize..255 {
-            predicates.push(syn::parse_quote! {
-                #name: #dialectic_path::backend::Receive<dialectic::backend::Choice<#n>>
             });
         }
         item.into_token_stream().into()

--- a/dialectic-null/src/lib.rs
+++ b/dialectic-null/src/lib.rs
@@ -74,6 +74,13 @@ impl std::error::Error for Error {}
 impl backend::Transmitter for Sender {
     type Error = Error;
     type Convention = Val;
+
+    fn send_choice<'async_lifetime, const LENGTH: usize>(
+        &'async_lifetime mut self,
+        _choice: Choice<LENGTH>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
+        Box::pin(async { Ok(()) })
+    }
 }
 
 impl backend::Transmit<()> for Sender {
@@ -102,6 +109,13 @@ impl<const LENGTH: usize> backend::Transmit<Choice<LENGTH>> for Sender {
 
 impl backend::Receiver for Receiver {
     type Error = Error;
+
+    fn recv_choice<'async_lifetime, const LENGTH: usize>(
+        &'async_lifetime mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>
+    {
+        Box::pin(async { 0.try_into().map_err(|_| Error { _private: () }) })
+    }
 }
 
 impl backend::Receive<()> for Receiver {

--- a/dialectic-null/src/lib.rs
+++ b/dialectic-null/src/lib.rs
@@ -15,7 +15,7 @@
 // Documentation configuration
 #![forbid(broken_intra_doc_links)]
 
-use dialectic::backend::{self, CallBy, Choice, Val};
+use dialectic::backend::{self, By, Choice, Val};
 use std::{convert::TryInto, future::Future, pin::Pin};
 
 /// Shorthand for a [`Chan`](dialectic::Chan) using a null [`Sender`] and [`Receiver`].
@@ -59,7 +59,9 @@ pub fn channel() -> (Sender, Receiver) {
 ///
 /// No such errors are possible, so this type cannot be constructed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Error {}
+pub struct Error {
+    _private: (),
+}
 
 impl std::fmt::Display for Error {
     fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -72,19 +74,24 @@ impl std::error::Error for Error {}
 impl backend::Transmitter for Sender {
     type Error = Error;
     type Convention = Val;
-
-    fn send_choice<'async_lifetime, const N: usize>(
-        &'async_lifetime mut self,
-        _choice: Choice<N>,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
-        Box::pin(async { Ok(()) })
-    }
 }
 
 impl backend::Transmit<()> for Sender {
     fn send<'a, 'async_lifetime>(
         &'async_lifetime mut self,
-        _message: <() as CallBy<Val>>::Type,
+        _message: <() as By<Val>>::Type,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
+    where
+        'a: 'async_lifetime,
+    {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+impl<const LENGTH: usize> backend::Transmit<Choice<LENGTH>> for Sender {
+    fn send<'a, 'async_lifetime>(
+        &'async_lifetime mut self,
+        _message: <Choice<LENGTH> as By<Val>>::Type,
     ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
     where
         'a: 'async_lifetime,
@@ -95,13 +102,6 @@ impl backend::Transmit<()> for Sender {
 
 impl backend::Receiver for Receiver {
     type Error = Error;
-
-    fn recv_choice<'async_lifetime, const N: usize>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Choice<N>, Self::Error>> + Send + 'async_lifetime>>
-    {
-        Box::pin(async { Ok(0.try_into().unwrap()) })
-    }
 }
 
 impl backend::Receive<()> for Receiver {
@@ -109,5 +109,14 @@ impl backend::Receive<()> for Receiver {
         &'async_lifetime mut self,
     ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
         Box::pin(async { Ok(()) })
+    }
+}
+
+impl<const LENGTH: usize> backend::Receive<Choice<LENGTH>> for Receiver {
+    fn recv<'async_lifetime>(
+        &'async_lifetime mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>
+    {
+        Box::pin(async { 0.try_into().map_err(|_| Error { _private: () }) })
     }
 }

--- a/dialectic-tokio-mpsc/src/lib.rs
+++ b/dialectic-tokio-mpsc/src/lib.rs
@@ -13,7 +13,7 @@
 // Documentation configuration
 #![forbid(broken_intra_doc_links)]
 
-use dialectic::backend::{self, CallBy, Choice, Val};
+use dialectic::backend::{self, By, Val};
 use std::{any::Any, future::Future, pin::Pin};
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -144,19 +144,12 @@ pub enum RecvError {
 impl backend::Transmitter for Sender {
     type Error = SendError<Box<dyn Any + Send>>;
     type Convention = Val;
-
-    fn send_choice<'async_lifetime, const N: usize>(
-        &'async_lifetime mut self,
-        choice: Choice<N>,
-    ) -> Pin<Box<(dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime)>> {
-        <Self as backend::Transmit<Choice<N>>>::send(self, choice)
-    }
 }
 
 impl<T: Send + Any> backend::Transmit<T> for Sender {
     fn send<'a, 'async_lifetime>(
         &'async_lifetime mut self,
-        message: <T as CallBy<'a, Val>>::Type,
+        message: <T as By<'a, Val>>::Type,
     ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
     where
         'a: 'async_lifetime,
@@ -167,13 +160,6 @@ impl<T: Send + Any> backend::Transmit<T> for Sender {
 
 impl backend::Receiver for Receiver {
     type Error = RecvError;
-
-    fn recv_choice<'async_lifetime, const N: usize>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<(dyn Future<Output = Result<Choice<N>, Self::Error>> + Send + 'async_lifetime)>>
-    {
-        <Self as backend::Receive<Choice<N>>>::recv(self)
-    }
 }
 
 impl<T: Send + Any> backend::Receive<T> for Receiver {
@@ -195,19 +181,12 @@ impl<T: Send + Any> backend::Receive<T> for Receiver {
 impl backend::Transmitter for UnboundedSender {
     type Error = SendError<Box<dyn Any + Send>>;
     type Convention = Val;
-
-    fn send_choice<'async_lifetime, const N: usize>(
-        &'async_lifetime mut self,
-        choice: Choice<N>,
-    ) -> Pin<Box<(dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime)>> {
-        <Self as backend::Transmit<Choice<N>>>::send(self, choice)
-    }
 }
 
 impl<T: Send + Any> backend::Transmit<T> for UnboundedSender {
     fn send<'a, 'async_lifetime>(
         &'async_lifetime mut self,
-        message: <T as CallBy<'a, Val>>::Type,
+        message: <T as By<'a, Val>>::Type,
     ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
     where
         'a: 'async_lifetime,
@@ -218,13 +197,6 @@ impl<T: Send + Any> backend::Transmit<T> for UnboundedSender {
 
 impl backend::Receiver for UnboundedReceiver {
     type Error = RecvError;
-
-    fn recv_choice<'async_lifetime, const N: usize>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<(dyn Future<Output = Result<Choice<N>, Self::Error>> + Send + 'async_lifetime)>>
-    {
-        <Self as backend::Receive<Choice<N>>>::recv(self)
-    }
 }
 
 impl<T: Send + Any> backend::Receive<T> for UnboundedReceiver {

--- a/dialectic-tokio-mpsc/src/lib.rs
+++ b/dialectic-tokio-mpsc/src/lib.rs
@@ -13,7 +13,7 @@
 // Documentation configuration
 #![forbid(broken_intra_doc_links)]
 
-use dialectic::backend::{self, By, Val};
+use dialectic::backend::{self, By, Choice, Val};
 use std::{any::Any, future::Future, pin::Pin};
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -144,6 +144,13 @@ pub enum RecvError {
 impl backend::Transmitter for Sender {
     type Error = SendError<Box<dyn Any + Send>>;
     type Convention = Val;
+
+    fn send_choice<'async_lifetime, const LENGTH: usize>(
+        &'async_lifetime mut self,
+        choice: Choice<LENGTH>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
+        <Self as backend::Transmit<Choice<LENGTH>>>::send(self, choice)
+    }
 }
 
 impl<T: Send + Any> backend::Transmit<T> for Sender {
@@ -160,6 +167,13 @@ impl<T: Send + Any> backend::Transmit<T> for Sender {
 
 impl backend::Receiver for Receiver {
     type Error = RecvError;
+
+    fn recv_choice<'async_lifetime, const LENGTH: usize>(
+        &'async_lifetime mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>
+    {
+        <Self as backend::Receive<Choice<LENGTH>>>::recv(self)
+    }
 }
 
 impl<T: Send + Any> backend::Receive<T> for Receiver {
@@ -181,6 +195,13 @@ impl<T: Send + Any> backend::Receive<T> for Receiver {
 impl backend::Transmitter for UnboundedSender {
     type Error = SendError<Box<dyn Any + Send>>;
     type Convention = Val;
+
+    fn send_choice<'async_lifetime, const LENGTH: usize>(
+        &'async_lifetime mut self,
+        choice: Choice<LENGTH>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
+        <Self as backend::Transmit<Choice<LENGTH>>>::send(self, choice)
+    }
 }
 
 impl<T: Send + Any> backend::Transmit<T> for UnboundedSender {
@@ -197,6 +218,13 @@ impl<T: Send + Any> backend::Transmit<T> for UnboundedSender {
 
 impl backend::Receiver for UnboundedReceiver {
     type Error = RecvError;
+
+    fn recv_choice<'async_lifetime, const LENGTH: usize>(
+        &'async_lifetime mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>
+    {
+        <Self as backend::Receive<Choice<LENGTH>>>::recv(self)
+    }
 }
 
 impl<T: Send + Any> backend::Receive<T> for UnboundedReceiver {

--- a/dialectic-tokio-serde-bincode/src/lib.rs
+++ b/dialectic-tokio-serde-bincode/src/lib.rs
@@ -58,7 +58,7 @@ where
 ///
 /// The `max_length` parameter indicates the maximum length of any message received or sent. An
 /// error is thrown during encoding and decoding if a message would exceed this length.
-pub fn length_delimited_bincode<W: AsyncWrite, R: AsyncRead>(
+pub fn length_delimited<W: AsyncWrite, R: AsyncRead>(
     writer: W,
     reader: R,
     length_field_bytes: usize,

--- a/dialectic-tokio-serde-json/src/lib.rs
+++ b/dialectic-tokio-serde-json/src/lib.rs
@@ -65,7 +65,7 @@ impl<Input: AsRef<str>> Deserializer<Input> for Json {
 ///
 /// The `max_length` parameter indicates the maximum length of any message received or sent. An
 /// error is thrown during encoding and decoding if a message exceeds this length.
-pub fn json_lines<W: AsyncWrite, R: AsyncRead>(
+pub fn lines<W: AsyncWrite, R: AsyncRead>(
     writer: W,
     reader: R,
     max_length: usize,

--- a/dialectic-tokio-serde/Cargo.toml
+++ b/dialectic-tokio-serde/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/boltlabs-inc/dialectic"
 homepage = "https://github.com/boltlabs-inc/dialectic"
 
 [dependencies]
-call-by = "0.1"
 dialectic = { path = "../dialectic", features = ["serde"] }
 futures = { version = "0.3", default-features = false }
 serde = { version = "1" }

--- a/dialectic-tokio-serde/src/lib.rs
+++ b/dialectic-tokio-serde/src/lib.rs
@@ -31,8 +31,7 @@
 use std::{future::Future, pin::Pin};
 
 use dialectic::{
-    backend::{self, Choice, Receive, Ref, Transmit},
-    call_by::By,
+    backend::{self, By, Choice, Receive, Ref, Transmit},
     Chan,
 };
 use futures::sink::SinkExt;

--- a/dialectic/Cargo.toml
+++ b/dialectic/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 thiserror = "1"
-call-by = "0.1"
+call-by = { version = "0.2" }
 tokio = { version = "1", optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
@@ -24,6 +24,8 @@ derivative = "2.1"
 pin-project = "1"
 static_assertions = "1.1"
 dialectic-macro = { version = "0.1", path = "../dialectic-macro" }
+lazy_static = "1.4"
+array-init = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/dialectic/Cargo.toml
+++ b/dialectic/Cargo.toml
@@ -24,8 +24,6 @@ derivative = "2.1"
 pin-project = "1"
 static_assertions = "1.1"
 dialectic-macro = { version = "0.1", path = "../dialectic-macro" }
-lazy_static = "1.4"
-array-init = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/dialectic/examples/common.rs
+++ b/dialectic/examples/common.rs
@@ -3,7 +3,6 @@ use dialectic_tokio_serde::codec::LengthDelimitedCodec;
 use dialectic_tokio_serde_bincode::Bincode;
 
 use colored::*;
-pub use serde::{Deserialize, Serialize};
 use std::{error::Error, fmt::Debug, future::Future, io, process};
 use structopt::StructOpt;
 use tokio::{
@@ -59,7 +58,7 @@ where
     P: Session,
 {
     let (rx, tx) = socket.into_split();
-    let (tx, rx) = dialectic_tokio_serde_bincode::length_delimited_bincode(tx, rx, 4, max_length);
+    let (tx, rx) = dialectic_tokio_serde_bincode::length_delimited(tx, rx, 4, max_length);
     P::wrap(tx, rx)
 }
 

--- a/dialectic/examples/template.rs
+++ b/dialectic/examples/template.rs
@@ -4,7 +4,7 @@ use tokio::io::{BufReader, Stdin, Stdout};
 
 mod common;
 #[allow(unused)]
-use common::{demo, prompt, TcpChan};
+use common::{demo, prompt};
 
 #[tokio::main]
 async fn main() {
@@ -17,11 +17,17 @@ type Client = Session! {
 };
 
 /// The implementation of the client.
-async fn client(
+#[Transmitter(Tx ref for /* add types needed by session here */)]
+#[Receiver(Rx for /* add types needed by session here */)]
+async fn client<Tx, Rx>(
     #[allow(unused)] mut input: BufReader<Stdin>,
     #[allow(unused)] mut output: Stdout,
-    #[allow(unused_mut)] mut chan: TcpChan<Client>,
-) -> Result<(), Box<dyn Error>> {
+    #[allow(unused_mut)] mut chan: Chan<Client, Tx, Rx>,
+) -> Result<(), Box<dyn Error>>
+where
+    Tx::Error: Error + Send,
+    Rx::Error: Error + Send,
+{
     // Do something with the channel...
     chan.close();
     Ok(())
@@ -31,7 +37,15 @@ async fn client(
 type Server = <Client as Session>::Dual;
 
 /// The implementation of the server for each client connection.
-async fn server(#[allow(unused_mut)] mut chan: TcpChan<Server>) -> Result<(), Box<dyn Error>> {
+#[Transmitter(Tx ref for /* add types needed by session here */)]
+#[Receiver(Rx for /* add types needed by session here */ )]
+async fn server<Tx, Rx>(
+    #[allow(unused_mut)] mut chan: Chan<Server, Tx, Rx>,
+) -> Result<(), Box<dyn Error>>
+where
+    Tx::Error: Error + Send,
+    Rx::Error: Error + Send,
+{
     // Do something with the channel...
     chan.close();
     Ok(())

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -7,9 +7,10 @@
 //! session.
 //!
 //! Functions which are generic over their backend will in turn need to specify the bounds
-//! `Transmit<T>` and `Receive<T>` for all `T`s they send and receive, respectively. The
-//! [`Transmitter`](macro@crate::Transmitter) and [`Receiver`](macro@crate::Receiver) attribute
-//! macros make this bound specification succinct; see their documentation for more details.
+//! [`Transmit<T>`](Transmit) and [`Receive<T>`](Receive) for all `T`s they send and receive,
+//! respectively. The [`Transmitter`](macro@crate::Transmitter) and
+//! [`Receiver`](macro@crate::Receiver) attribute macros make this bound specification succinct; see
+//! their documentation for more details.
 
 #[doc(no_inline)]
 pub use call_by::{By, Convention, Mut, Ref, Val};
@@ -24,7 +25,7 @@ pub use choice::*;
 /// across the channel. This is a super-trait of [`Transmit`], which is what's actually needed to
 /// receive particular values over a [`Chan`](crate::Chan).
 ///
-/// If you're writing a function and need a lot of different `Transmit<T>` bounds, the
+/// If you're writing a function and need a lot of different [`Transmit<T>`](Transmit) bounds, the
 /// [`Transmitter`](macro@crate::Transmitter) attribute macro can help you specify them more
 /// succinctly.
 pub trait Transmitter {
@@ -44,9 +45,9 @@ pub trait Transmitter {
     ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>;
 }
 
-/// If a transport is `Transmit<T>`, we can use it to [`send`](Transmit::send) a message of type `T`
-/// by [`Val`] or [`Ref`], depending on the calling convention specified by its [`Transmitter`]
-/// implementation.
+/// If a transport is [`Transmit<T>`](Transmit), we can use it to [`send`](Transmit::send) a message
+/// of type `T` by [`Val`] or [`Ref`], depending on the calling convention specified by its
+/// [`Transmitter`] implementation.
 ///
 /// If you're writing a function and need a lot of different `Transmit<T>` bounds, the
 /// [`Transmitter`](macro@crate::Transmitter) attribute macro can help you specify them more
@@ -60,7 +61,8 @@ pub trait Transmitter {
 ///
 /// [`dialectic_tokio_mpsc`]: https://docs.rs/dialectic-tokio-mpsc
 ///
-/// [`dialectic_tokio_mpsc::Sender`]: https://docs.rs/dialectic-tokio-mpsc/latest/dialectic_tokio_mpsc/struct.Sender.html
+/// [`dialectic_tokio_mpsc::Sender`]:
+/// https://docs.rs/dialectic-tokio-mpsc/latest/dialectic_tokio_mpsc/struct.Sender.html
 pub trait Transmit<T>: Transmitter {
     /// Send a message using the [`Convention`] specified by the trait implementation.
     fn send<'a, 'async_lifetime>(
@@ -77,7 +79,7 @@ pub trait Transmit<T>: Transmitter {
 /// super-trait of [`Receive`], which is what's actually needed to receive particular values over a
 /// [`Chan`](crate::Chan).
 ///
-/// If you're writing a function and need a lot of different `Receive<T>` bounds, the
+/// If you're writing a function and need a lot of different [`Receive<T>`](Receive) bounds, the
 /// [`Receiver`](macro@crate::Receiver) attribute macro can help you specify them more succinctly.
 pub trait Receiver {
     /// The type of possible errors when receiving.
@@ -90,9 +92,10 @@ pub trait Receiver {
     ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>;
 }
 
-/// If a transport is `Receive<T>`, we can use it to [`recv`](Receive::recv) a message of type `T`.
+/// If a transport is [`Receive<T>`](Receive), we can use it to [`recv`](Receive::recv) a message of
+/// type `T`.
 ///
-/// If you're writing a function and need a lot of different `Receive<T>` bounds, the
+/// If you're writing a function and need a lot of different [`Receive<T>`](Receive) bounds, the
 /// [`Receiver`](macro@crate::Receiver) attribute macro can help you specify them more succinctly.
 ///
 /// # Examples

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -28,10 +28,12 @@ pub use choice::*;
 /// A backend transport used for transmitting (i.e. the `Tx` parameter of [`Chan`](crate::Chan))
 /// must implement [`Transmitter`], which specifies what type of errors it might return and whether
 /// it sends things by owned value or by reference, as well as giving a method to send [`Choice`]s
-/// across the channel.
+/// across the channel. This is a super-trait of [`Transmit`], which is what's actually needed to
+/// receive particular values over a [`Chan`](crate::Chan).
 ///
 /// If you're writing a function and need a lot of different `Transmit<T>` bounds, the
-/// [`Transmitter`](macro@crate::Transmitter) can help you specify them more succinctly.
+/// [`Transmitter`](macro@crate::Transmitter) attribute macro can help you specify them more
+/// succinctly.
 pub trait Transmitter {
     /// The type of possible errors when sending.
     type Error;
@@ -54,7 +56,8 @@ pub trait Transmitter {
 /// implementation.
 ///
 /// If you're writing a function and need a lot of different `Transmit<T>` bounds, the
-/// [`Transmitter`](macro@crate::Transmitter) can help you specify them more succinctly.
+/// [`Transmitter`](macro@crate::Transmitter) attribute macro can help you specify them more
+/// succinctly.
 ///
 /// # Examples
 ///
@@ -63,6 +66,7 @@ pub trait Transmitter {
 /// crate.
 ///
 /// [`dialectic_tokio_mpsc`]: https://docs.rs/dialectic-tokio-mpsc
+///
 /// [`dialectic_tokio_mpsc::Sender`]: https://docs.rs/dialectic-tokio-mpsc/latest/dialectic_tokio_mpsc/struct.Sender.html
 pub trait Transmit<T>: Transmitter {
     /// Send a message using the [`Convention`] specified by the trait implementation.
@@ -76,10 +80,12 @@ pub trait Transmit<T>: Transmitter {
 }
 
 /// A backend transport used for receiving (i.e. the `Rx` parameter of [`Chan`](crate::Chan)) must
-/// implement [`Receiver`], which specifies what type of errors it might return.
+/// implement [`Receiver`], which specifies what type of errors it might return. This is a
+/// super-trait of [`Receive`], which is what's actually needed to receive particular values over a
+/// [`Chan`](crate::Chan).
 ///
 /// If you're writing a function and need a lot of different `Receive<T>` bounds, the
-/// [`Receiver`](macro@crate::Receiver) can help you specify them more succinctly.
+/// [`Receiver`](macro@crate::Receiver) attribute macro can help you specify them more succinctly.
 pub trait Receiver {
     /// The type of possible errors when receiving.
     type Error;
@@ -94,7 +100,7 @@ pub trait Receiver {
 /// If a transport is `Receive<T>`, we can use it to [`recv`](Receive::recv) a message of type `T`.
 ///
 /// If you're writing a function and need a lot of different `Receive<T>` bounds, the
-/// [`Receiver`](macro@crate::Receiver) can help you specify them more succinctly.
+/// [`Receiver`](macro@crate::Receiver) attribute macro can help you specify them more succinctly.
 ///
 /// # Examples
 ///
@@ -103,7 +109,9 @@ pub trait Receiver {
 /// crate.
 ///
 /// [`dialectic_tokio_mpsc`]: https://docs.rs/dialectic-tokio-mpsc
-/// [`dialectic_tokio_mpsc::Receiver`]: https://docs.rs/dialectic-tokio-mpsc/latest/dialectic_tokio_mpsc/struct.Receiver.html
+///
+/// [`dialectic_tokio_mpsc::Receiver`]:
+/// https://docs.rs/dialectic-tokio-mpsc/latest/dialectic_tokio_mpsc/struct.Receiver.html
 pub trait Receive<T>: Receiver {
     /// Receive a message. This may require type annotations for disambiguation.
     fn recv<'async_lifetime>(

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -2,14 +2,14 @@
 //!
 //! A [`Chan<S, Tx, Rx>`](crate::Chan) is parameterized by its transmitting channel `Tx` and its
 //! receiving channel `Rx`. In order to use a `Chan` to run a session, these underlying channels
-//! must implement the traits [`Transmit`] and [`Receive`] for at least the types used in any given
+//! must implement the traits [`Transmitter`] and [`Receiver`], as well as [`Transmit<T>`](Transmit)
+//! and [`Receive<T>`](Receive) for at least the types `T` used in those capacities in any given
 //! session.
 //!
-//! Functions which are generic over their backend will need to specify `Transmit<T>` and
-//! `Receive<T>` for all `T`s they send and receive, respectively. The
-//! [`Transmitter`](macro@crate::Transmitter) and [`Receiver`](macro@crate::Receiver) macros are
-//! provided to streamline this process and eliminate almost all necessary/common trait bounds on
-//! generic backend type parameters.
+//! Functions which are generic over their backend will in turn need to specify the bounds
+//! `Transmit<T>` and `Receive<T>` for all `T`s they send and receive, respectively. The
+//! [`Transmitter`](macro@crate::Transmitter) and [`Receiver`](macro@crate::Receiver) attribute
+//! macros make this bound specification succinct; see their documentation for more details.
 
 #[doc(no_inline)]
 pub use call_by::{By, Convention, Mut, Ref, Val};

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -11,6 +11,12 @@
 //! the sending channel `Tx` must implement `Transmit<Choice<N>, Val>`, and the receiving channel
 //! `Rx` must implement `Receive<Choice<N>>`, for all `const N: usize`. For more information, see
 //! [`Choice`](crate::Choice).
+//!
+//! Functions which are generic over their backend will need to specify `Transmit<T>` and
+//! `Receive<T>` for all `T`s they send and receive, respectively. The
+//! [`Transmitter`](macro@crate::Transmitter) and [`Receiver`](macro@crate::Receiver) macros are
+//! provided to streamline this process and eliminate almost all necessary/common trait bounds on
+//! generic backend type parameters.
 
 #[doc(no_inline)]
 pub use call_by::*;
@@ -23,6 +29,9 @@ pub use choice::*;
 /// must implement [`Transmitter`], which specifies what type of errors it might return and whether
 /// it sends things by owned value or by reference, as well as giving a method to send [`Choice`]s
 /// across the channel.
+///
+/// If you're writing a function and need a lot of different `Transmit<T>` bounds, the
+/// [`Transmitter`](macro@crate::Transmitter) can help you specify them more succinctly.
 pub trait Transmitter {
     /// The type of possible errors when sending.
     type Error;
@@ -43,6 +52,9 @@ pub trait Transmitter {
 /// If a transport is `Transmit<T>`, we can use it to [`send`](Transmit::send) a message of type `T`
 /// by [`Val`] or [`Ref`], depending on the calling convention specified by its [`Transmitter`]
 /// implementation.
+///
+/// If you're writing a function and need a lot of different `Transmit<T>` bounds, the
+/// [`Transmitter`](macro@crate::Transmitter) can help you specify them more succinctly.
 ///
 /// # Examples
 ///
@@ -65,6 +77,9 @@ pub trait Transmit<T>: Transmitter {
 
 /// A backend transport used for receiving (i.e. the `Rx` parameter of [`Chan`](crate::Chan)) must
 /// implement [`Receiver`], which specifies what type of errors it might return.
+///
+/// If you're writing a function and need a lot of different `Receive<T>` bounds, the
+/// [`Receiver`](macro@crate::Receiver) can help you specify them more succinctly.
 pub trait Receiver {
     /// The type of possible errors when receiving.
     type Error;
@@ -77,6 +92,9 @@ pub trait Receiver {
 }
 
 /// If a transport is `Receive<T>`, we can use it to [`recv`](Receive::recv) a message of type `T`.
+///
+/// If you're writing a function and need a lot of different `Receive<T>` bounds, the
+/// [`Receiver`](macro@crate::Receiver) can help you specify them more succinctly.
 ///
 /// # Examples
 ///

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -12,7 +12,7 @@
 //! generic backend type parameters.
 
 #[doc(no_inline)]
-pub use call_by::*;
+pub use call_by::{By, Convention, Mut, Ref, Val};
 use std::{future::Future, pin::Pin};
 
 mod choice;

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -1,16 +1,9 @@
-//! Transport backends for [`Chan`](crate::Chan), and the traits they implement in order to be used
-//! as such.
+//! The interface implemented by all transport backends for a [`Chan`](crate::Chan).
 //!
 //! A [`Chan<S, Tx, Rx>`](crate::Chan) is parameterized by its transmitting channel `Tx` and its
 //! receiving channel `Rx`. In order to use a `Chan` to run a session, these underlying channels
 //! must implement the traits [`Transmit`] and [`Receive`] for at least the types used in any given
-//! session (and in the case of [`Transmit`], for the particular calling conventions used to pass
-//! those types to [`Chan::send`](crate::Chan::send)).
-//!
-//! Additionally, in order to support [`offer!`](crate::offer) and [`choose`](crate::Chan::choose),
-//! the sending channel `Tx` must implement `Transmit<Choice<N>, Val>`, and the receiving channel
-//! `Rx` must implement `Receive<Choice<N>>`, for all `const N: usize`. For more information, see
-//! [`Choice`](crate::Choice).
+//! session.
 //!
 //! Functions which are generic over their backend will need to specify `Transmit<T>` and
 //! `Receive<T>` for all `T`s they send and receive, respectively. The

--- a/dialectic/src/backend/choice.rs
+++ b/dialectic/src/backend/choice.rs
@@ -64,30 +64,6 @@ pub struct Choice<const N: usize> {
     choice: u8,
 }
 
-lazy_static::lazy_static! {
-    static ref CHOICES: [u8; 256] = {
-        let mut n: u8 = 0;
-        array_init::array_init(|_| {
-            let i = n;
-            n += 1;
-            i
-        })
-    };
-}
-
-impl<const N: usize> Choice<N> {
-    /// Convert this `Choice` into a `'static` reference to the same `Choice`.
-    ///
-    /// This is possible because there are only 256 possible `Choice`s, and they are all enumerated
-    /// in a [`lazy_static`] block on the first execution of this function.
-    pub fn into_static_ref(self) -> &'static Choice<N> {
-        let n: &'static u8 = &CHOICES[self.choice as usize];
-        // This conversion is safe because `n` is `'static` and `Choice` is `#[repr(transparent)]`,
-        // so the pointer cast is between two equal representations.
-        unsafe { &*(n as *const u8 as *const Choice<N>) }
-    }
-}
-
 // Choice<0> is unconstructable, but for all N, 0 is a Choice<N + 1>:
 impl<M: Unary, const N: usize> Default for Choice<N>
 where

--- a/dialectic/src/chan.rs
+++ b/dialectic/src/chan.rs
@@ -1,5 +1,6 @@
 //! The [`Chan`] type is defined here. Typically, you don't need to import this module, and should
 //! use the [`Chan`](super::Chan) type synonym instead.
+use call_by::By;
 use futures::Future;
 use pin_project::pin_project;
 use std::{

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -70,12 +70,11 @@ Dialectic. A quick summary:
   both sides of a channel or just one side, respectively.
 - Backend transports suitable for being wrapped in a [`Chan`] are provided in [`backend`], along
   with the [`Transmit`] and [`Receive`] traits necessary to implement your own.
-- When writing functions which are polymorphic over their backend type, you will need to specify
+- When writing functions which are generic over their backend type, you will need to specify
   [`Transmit`] and [`Receive`] bounds on your backend. If you have a lot of these, the
   [`macro@Transmitter`] and [`macro@Receiver`] attribute macros can help eliminate them by letting
-  you write them efficiently. All of the [examples](https://github.com/boltlabs-inc/dialectic/tree
-  main/dialectic/examples) are written to be backend-agnostic, so taking a look at them may help if
-  you get stuck.
+  you write them efficiently. All of the [examples](https://github.com/boltlabs-inc/dialectic/tree/main/dialectic/examples)
+  are written to be backend-agnostic, so taking a look at them may help if you get stuck.
 
 Once you've got a channel, here's what you can do:
 

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -120,8 +120,10 @@ mod chan;
 mod error;
 mod session;
 
+#[doc(no_inline)]
+pub use call_by;
 pub use chan::{Branches, Chan};
-pub use dialectic_macro::{offer, Session};
+pub use dialectic_macro::{offer, Receiver, Session, Transmitter};
 pub use error::{IncompleteHalf, SessionIncomplete, Unavailable};
 pub use session::Session;
 
@@ -155,5 +157,5 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use call_by::{Mut, Ref, Val};
     #[doc(no_inline)]
-    pub use dialectic_macro::{offer, Session};
+    pub use dialectic_macro::{offer, Receiver, Session, Transmitter};
 }

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -125,8 +125,6 @@ mod chan;
 mod error;
 mod session;
 
-#[doc(no_inline)]
-pub use call_by;
 pub use chan::{Branches, Chan};
 pub use dialectic_macro::{offer, Receiver, Session, Transmitter};
 pub use error::{IncompleteHalf, SessionIncomplete, Unavailable};

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -70,6 +70,12 @@ Dialectic. A quick summary:
   both sides of a channel or just one side, respectively.
 - Backend transports suitable for being wrapped in a [`Chan`] are provided in [`backend`], along
   with the [`Transmit`] and [`Receive`] traits necessary to implement your own.
+- When writing functions which are polymorphic over their backend type, you will need to specify
+  [`Transmit`] and [`Receive`] bounds on your backend. If you have a lot of these, the
+  [`macro@Transmitter`] and [`macro@Receiver`] attribute macros can help eliminate them by letting
+  you write them efficiently. All of the [examples](https://github.com/boltlabs-inc/dialectic/tree
+  main/dialectic/examples) are written to be backend-agnostic, so taking a look at them may help if
+  you get stuck.
 
 Once you've got a channel, here's what you can do:
 

--- a/dialectic/src/tutorial.rs
+++ b/dialectic/src/tutorial.rs
@@ -755,7 +755,7 @@ caveats of `call`, of which it is a close relative:
 
 # Writing backend-agnostic code
 
-When writing functions which are polymorphic over their backend type, you will need to specify [`Transmit`] and [`Receive`] bounds on your backend. If you have a lot of these, the [`macro@Transmitter`] and [`macro@Receiver`] attribute macros can help eliminate them by letting you write them efficiently. The following is an excerpt from the `tally` example:
+When writing functions which are generic over their backend type, you will need to specify [`Transmit`] and [`Receive`] bounds on your backend. If you have a lot of these, the [`macro@Transmitter`] and [`macro@Receiver`] attribute macros can help eliminate them by letting you write them efficiently. The following is an excerpt from the `tally` example:
 
 ```
 # #![allow(unused)]

--- a/dialectic/src/tutorial.rs
+++ b/dialectic/src/tutorial.rs
@@ -753,34 +753,56 @@ caveats of `call`, of which it is a close relative:
   before the future completes. This is subject to the same behavior as in [`call`](Chan::call),
   described below. [See here for more explanation](#errors-in-subroutines-what-not-to-do).
 
-# Writing backend-agnostic code
+# Writing backend-polymorphic code
 
-When writing functions which are generic over their backend type, you will need to specify [`Transmit`] and [`Receive`] bounds on your backend. If you have a lot of these, the [`macro@Transmitter`] and [`macro@Receiver`] attribute macros can help eliminate them by letting you write them efficiently. The following is an excerpt from the `tally` example:
+When writing functions which are polymorphic over their backend type, you will need to specify
+[`Transmit`] and [`Receive`] bounds on your backend. If you have a lot of these, the
+[`macro@Transmitter`] and [`macro@Receiver`] attribute macros can help eliminate them by letting
+you write them efficiently. For instance, suppose we have a protocol using the unit structs `T1`,
+`T2`, `T3`, `T4`, and `T5`. We can simplify writing bounds for the `run` function using these
+attributes.
 
 ```
-# #![allow(unused)]
-# use dialectic::prelude::*;
-# use std::error::Error;
-# use tokio::io::{Stdin, Stdout};
-# type Client = Session! {};
-# struct Operation;
-#[Transmitter(Tx ref for Operation, i64)]
-#[Receiver(Rx for i64)]
-async fn client<Tx, Rx>(
-    mut input: BufReader<Stdin>,
-    mut output: Stdout,
-    mut chan: Chan<Client, Tx, Rx>,
+use dialectic::prelude::*;
+use std::error::Error;
+
+type S = Session! {
+    send T1;
+    recv T2;
+    send T3;
+    recv T4;
+    send T5;
+};
+# struct T1;
+# struct T2;
+# struct T3;
+# struct T4;
+# struct T5;
+
+#[Transmitter(Tx move for T1, T3, T5)]
+#[Receiver(Rx for T2, T4)]
+async fn run<Tx, Rx>(
+    chan: Chan<S, Tx, Rx>,
 ) -> Result<(), Box<dyn Error>>
 where
     Tx::Error: Error + Send,
     Rx::Error: Error + Send,
 {
-    // ...
-#   Ok(())
+    let chan = chan.send(T1).await?;
+    let (T2, chan) = chan.recv().await?;
+    let chan = chan.send(T3).await?;
+    let (T4, chan) = chan.recv().await?;
+    let chan = chan.send(T5).await?;
+    chan.close();
+    Ok(())
 }
 ```
 
-All of the [examples](https://github.com/boltlabs-inc/dialectic/tree/main/dialectic/examples) are written to be backend-agnostic, so taking a look at them may help if you get stuck.
+For more details on the syntax for the [`macro@Transmitter`] and [`macro@Receiver`] attribute
+macros, see their documentation. Additionally, the code in the
+[examples](https://github.com/boltlabs-inc/dialectic/tree/main/dialectic/examples)
+is written to be backend-agnostic, and uses these attributes. They may prove an additional resource
+if you get stuck.
 
 # Wrapping up
 

--- a/dialectic/src/tutorial.rs
+++ b/dialectic/src/tutorial.rs
@@ -753,6 +753,35 @@ caveats of `call`, of which it is a close relative:
   before the future completes. This is subject to the same behavior as in [`call`](Chan::call),
   described below. [See here for more explanation](#errors-in-subroutines-what-not-to-do).
 
+# Writing backend-agnostic code
+
+When writing functions which are polymorphic over their backend type, you will need to specify [`Transmit`] and [`Receive`] bounds on your backend. If you have a lot of these, the [`macro@Transmitter`] and [`macro@Receiver`] attribute macros can help eliminate them by letting you write them efficiently. The following is an excerpt from the `tally` example:
+
+```
+# #![allow(unused)]
+# use dialectic::prelude::*;
+# use std::error::Error;
+# use tokio::io::{Stdin, Stdout};
+# type Client = Session! {};
+# struct Operation;
+#[Transmitter(Tx ref for Operation, i64)]
+#[Receiver(Rx for i64)]
+async fn client<Tx, Rx>(
+    mut input: BufReader<Stdin>,
+    mut output: Stdout,
+    mut chan: Chan<Client, Tx, Rx>,
+) -> Result<(), Box<dyn Error>>
+where
+    Tx::Error: Error + Send,
+    Rx::Error: Error + Send,
+{
+    // ...
+#   Ok(())
+}
+```
+
+All of the [examples](https://github.com/boltlabs-inc/dialectic/tree/main/dialectic/examples) are written to be backend-agnostic, so taking a look at them may help if you get stuck.
+
 # Wrapping up
 
 We've now finished our tour of everything you need to get started programming with Dialectic! ✨


### PR DESCRIPTION
This alteration removes the necessity of asking backend implementors to specially treat `Choice`,
which can lead to code duplication. Instead, new functionality in `call-by` version 0.2.0 is used to
send `Choice` values by val/ref/mut as needed by the underlying transport. However, this comes at
the cost of it being more difficult to write out the bounds on `Tx` and `Rx` in generic situations,
so two new procedural macros are introduced: `Receiver` and `Transmitter`, which tack the correct
bounds onto the `where`-clause of the item they are attached to.

Todo:
- [x] Add documentation links to `Transmitter` and `Receiver` attribute macros to the tutorial and main reference docs, and `Transmit`/`Receive`/`Transmitter`/`Receiver` trait documentation. Also reference in the `backend` module docs?
- [x] Update the examples to be polymorphic over backends, and show how nice that can be with the attribute macros.
- [x] Revert to using `send_choice`/`recv_choice` functions to avoid constraint explosion.