### PR TITLE
WIP: Backend based on poll-functions rather than boxed futures

### DIFF
--- a/dialectic-macro/src/lib.rs
+++ b/dialectic-macro/src/lib.rs
@@ -679,16 +679,15 @@ pub fn Transmitter(
     if let Some(predicates) = where_predicates_mut(&mut item) {
         predicates.push(if let Some(mutability) = mutability {
             syn::parse_quote! {
-                #name: ::std::marker::Send
-                + #dialectic_path::backend::Transmitter<Convention = #mutability>
-                + 'static
+                #name: #dialectic_path::backend::Transmitter<Convention = #mutability>
             }
         } else {
             syn::parse_quote! {
-                #name: ::std::marker::Send
-                + #dialectic_path::backend::Transmitter
-                + 'static
+                #name: #dialectic_path::backend::Transmitter
             }
+        });
+        predicates.push(syn::parse_quote! {
+            #name: #dialectic_path::backend::TransmitChoice
         });
         for ty in types {
             predicates.push(syn::parse_quote! {
@@ -790,9 +789,7 @@ pub fn Receiver(
     let mut item = parse_macro_input!(input as syn::Item);
     if let Some(predicates) = where_predicates_mut(&mut item) {
         predicates.push(syn::parse_quote! {
-            #name: ::std::marker::Send
-            + #dialectic_path::backend::Receiver
-            + 'static
+            #name: #dialectic_path::backend::Receiver + #dialectic_path::backend::ReceiveChoice
         });
         for ty in types {
             predicates.push(syn::parse_quote! {

--- a/dialectic-null/src/lib.rs
+++ b/dialectic-null/src/lib.rs
@@ -16,7 +16,12 @@
 #![forbid(broken_intra_doc_links)]
 
 use dialectic::backend::{self, By, Choice, Val};
-use std::{convert::TryInto, future::Future, pin::Pin};
+use std::{
+    convert::TryInto,
+    pin::Pin,
+    result::Result,
+    task::{Context, Poll},
+};
 
 /// Shorthand for a [`Chan`](dialectic::Chan) using a null [`Sender`] and [`Receiver`].
 ///
@@ -74,63 +79,46 @@ impl std::error::Error for Error {}
 impl backend::Transmitter for Sender {
     type Error = Error;
     type Convention = Val;
+    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
 
-    fn send_choice<'async_lifetime, const LENGTH: usize>(
-        &'async_lifetime mut self,
-        _choice: Choice<LENGTH>,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
-        Box::pin(async { Ok(()) })
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+    fn start_send_choice<const LENGTH: usize>(
+        self: Pin<&mut Self>,
+        _: Choice<LENGTH>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
     }
 }
 
 impl backend::Transmit<()> for Sender {
-    fn send<'a, 'async_lifetime>(
-        &'async_lifetime mut self,
-        _message: <() as By<Val>>::Type,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
+    fn start_send<'a>(self: Pin<&mut Self>, _: <() as By<'a, Val>>::Type) -> Result<(), Self::Error>
     where
-        'a: 'async_lifetime,
+        (): By<'a, Val>,
     {
-        Box::pin(async { Ok(()) })
-    }
-}
-
-impl<const LENGTH: usize> backend::Transmit<Choice<LENGTH>> for Sender {
-    fn send<'a, 'async_lifetime>(
-        &'async_lifetime mut self,
-        _message: <Choice<LENGTH> as By<Val>>::Type,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
-    where
-        'a: 'async_lifetime,
-    {
-        Box::pin(async { Ok(()) })
+        Ok(())
     }
 }
 
 impl backend::Receiver for Receiver {
     type Error = Error;
-
-    fn recv_choice<'async_lifetime, const LENGTH: usize>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>
-    {
-        Box::pin(async { 0.try_into().map_err(|_| Error { _private: () }) })
+    fn poll_recv_choice<const LENGTH: usize>(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<Choice<LENGTH>, Self::Error>> {
+        Poll::Ready(0.try_into().map_err(|_| Error { _private: () }))
     }
 }
 
 impl backend::Receive<()> for Receiver {
-    fn recv<'async_lifetime>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>> {
-        Box::pin(async { Ok(()) })
-    }
-}
-
-impl<const LENGTH: usize> backend::Receive<Choice<LENGTH>> for Receiver {
-    fn recv<'async_lifetime>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>
-    {
-        Box::pin(async { 0.try_into().map_err(|_| Error { _private: () }) })
+    fn poll_recv(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 }

--- a/dialectic-null/src/lib.rs
+++ b/dialectic-null/src/lib.rs
@@ -79,6 +79,7 @@ impl std::error::Error for Error {}
 impl backend::Transmitter for Sender {
     type Error = Error;
     type Convention = Val;
+
     fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
@@ -90,6 +91,9 @@ impl backend::Transmitter for Sender {
     fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
+}
+
+impl backend::TransmitChoice for Sender {
     fn start_send_choice<const LENGTH: usize>(
         self: Pin<&mut Self>,
         _: Choice<LENGTH>,
@@ -109,6 +113,9 @@ impl backend::Transmit<()> for Sender {
 
 impl backend::Receiver for Receiver {
     type Error = Error;
+}
+
+impl backend::ReceiveChoice for Receiver {
     fn poll_recv_choice<const LENGTH: usize>(
         self: Pin<&mut Self>,
         _: &mut Context<'_>,

--- a/dialectic-tokio-mpsc/Cargo.toml
+++ b/dialectic-tokio-mpsc/Cargo.toml
@@ -11,7 +11,9 @@ homepage = "https://github.com/boltlabs-inc/dialectic"
 [dependencies]
 dialectic = { version = "0.4", path = "../dialectic" }
 thiserror = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["sync"] }
+tokio-util = "0.6"
+futures = { version = "0.3", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/dialectic-tokio-mpsc/src/lib.rs
+++ b/dialectic-tokio-mpsc/src/lib.rs
@@ -58,18 +58,46 @@ pub type UnboundedChan<P> = dialectic::Chan<P, UnboundedSender, UnboundedReceive
 #[derive(Debug)]
 pub struct Receiver(mpsc::Receiver<Box<dyn Any + Send>>);
 
+impl Receiver {
+    /// Wrap a [`tokio::sync::mpsc::Receiver`] to create a new [`Receiver`].
+    pub fn new(receiver: mpsc::Receiver<Box<dyn Any + Send>>) -> Self {
+        Self(receiver)
+    }
+}
+
 /// A bounded sender for dynamically typed values. See [`tokio::sync::mpsc::Sender`].
 #[derive(Debug, Clone)]
 pub struct Sender(PollSender<Box<dyn Any + Send>>);
+
+impl Sender {
+    /// Wrap a [`tokio::sync::mpsc::Sender`] to create a new [`Sender`].
+    pub fn new(sender: mpsc::Sender<Box<dyn Any + Send>>) -> Self {
+        Self(PollSender::new(sender))
+    }
+}
 
 /// An unbounded receiver for dynamically typed values. See
 /// [`tokio::sync::mpsc::UnboundedReceiver`].
 #[derive(Debug)]
 pub struct UnboundedReceiver(mpsc::UnboundedReceiver<Box<dyn Any + Send>>);
 
+impl UnboundedReceiver {
+    /// Wrap a [`tokio::sync::mpsc::UnboundedReceiver`] to create a new [`UnboundedReceiver`].
+    pub fn new(receiver: mpsc::UnboundedReceiver<Box<dyn Any + Send>>) -> Self {
+        Self(receiver)
+    }
+}
+
 /// An unbounded sender for dynamically typed values. See [`tokio::sync::mpsc::UnboundedSender`].
 #[derive(Debug, Clone)]
 pub struct UnboundedSender(mpsc::UnboundedSender<Box<dyn Any + Send>>);
+
+impl UnboundedSender {
+    /// Wrap a [`tokio::sync::mpsc::UnboundedSender`] to create a new [`UnboundedSender`].
+    pub fn new(sender: mpsc::UnboundedSender<Box<dyn Any + Send>>) -> Self {
+        Self(sender)
+    }
+}
 
 /// Create a bounded mpsc channel for transporting dynamically typed values.
 ///
@@ -83,7 +111,7 @@ pub struct UnboundedSender(mpsc::UnboundedSender<Box<dyn Any + Send>>);
 /// ```
 pub fn channel(buffer: usize) -> (Sender, Receiver) {
     let (tx, rx) = mpsc::channel(buffer);
-    (Sender(PollSender::new(tx)), Receiver(rx))
+    (Sender::new(tx), Receiver::new(rx))
 }
 
 /// Create an unbounded mpsc channel for transporting dynamically typed values.

--- a/dialectic/Cargo.toml
+++ b/dialectic/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 thiserror = "1"
-call-by = { version = "0.2.1", path = "../../call-by" }
+call-by = { version = "0.2" }
 tokio = { version = "1", optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/dialectic/Cargo.toml
+++ b/dialectic/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 thiserror = "1"
-call-by = { version = "0.2" }
+call-by = { version = "0.2.1", path = "../../call-by" }
 tokio = { version = "1", optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/dialectic/benches/mpsc.rs
+++ b/dialectic/benches/mpsc.rs
@@ -2,9 +2,8 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use dialectic::prelude::*;
 use dialectic::Unavailable;
 use dialectic_tokio_mpsc as mpsc;
-use std::time::Instant;
-use std::{sync::Arc, time::Duration};
-use tokio::runtime::Runtime;
+use std::{any::Any, sync::Arc, time::Duration, time::Instant};
+use tokio::{runtime::Runtime, sync::mpsc as tokio_mpsc};
 
 type Server = Session! { loop { send bool } };
 type Client = <Server as Session>::Dual;
@@ -17,8 +16,8 @@ async fn dialectic_client(mut chan: Chan<Client, Unavailable, mpsc::Receiver>) {
     } {}
 }
 
-async fn plain_client(mut rx: mpsc::Receiver) {
-    while *rx.0.recv().await.unwrap().downcast().unwrap() {}
+async fn plain_client(mut rx: tokio_mpsc::Receiver<Box<dyn Send + Any>>) {
+    while *rx.recv().await.unwrap().downcast().unwrap() {}
 }
 
 async fn dialectic_server(iterations: usize, mut chan: Chan<Server, mpsc::Sender, Unavailable>) {
@@ -28,17 +27,17 @@ async fn dialectic_server(iterations: usize, mut chan: Chan<Server, mpsc::Sender
     let _ = chan.send(false).await.unwrap();
 }
 
-async fn plain_server(iterations: usize, tx: mpsc::Sender) {
+async fn plain_server(iterations: usize, tx: tokio_mpsc::Sender<Box<dyn Send + Any>>) {
     for _ in 0..iterations {
-        tx.0.send(Box::new(true)).await.unwrap();
+        tx.send(Box::new(true)).await.unwrap();
     }
-    tx.0.send(Box::new(false)).await.unwrap();
+    tx.send(Box::new(false)).await.unwrap();
 }
 
 fn bench_send_recv(c: &mut Criterion) {
     let size: usize = 1024;
 
-    let mut dialectic_group = c.benchmark_group("dialectic");
+    let mut dialectic_group = c.benchmark_group("dialectic/tokio/mpsc");
     dialectic_group.throughput(Throughput::Elements(size as u64));
 
     let rt = Arc::new(Runtime::new().unwrap());
@@ -48,9 +47,9 @@ fn bench_send_recv(c: &mut Criterion) {
             let mut total_duration = Duration::from_secs(0);
             for _ in 0..iters {
                 // Pre-populate the channel with things to receive
-                let (tx, rx) = mpsc::channel(s + 1);
+                let (tx, rx) = tokio_mpsc::channel(s + 1);
                 rt.block_on(plain_server(s, tx.clone()));
-                let client = Client::wrap(Unavailable::default(), rx);
+                let client = Client::wrap(Unavailable::default(), mpsc::Receiver::new(rx));
                 let start = Instant::now();
                 rt.block_on(dialectic_client(client));
                 total_duration += start.elapsed();
@@ -77,7 +76,7 @@ fn bench_send_recv(c: &mut Criterion) {
 
     drop(dialectic_group);
 
-    let mut plain_group = c.benchmark_group("plain");
+    let mut plain_group = c.benchmark_group("plain/tokio/mpsc");
     plain_group.throughput(Throughput::Elements(size as u64));
 
     plain_group.bench_with_input(BenchmarkId::new("recv", size), &size, |b, &s| {
@@ -85,7 +84,7 @@ fn bench_send_recv(c: &mut Criterion) {
             let mut total_duration = Duration::from_secs(0);
             for _ in 0..iters {
                 // Pre-populate the channel with things to receive
-                let (tx, rx) = mpsc::channel(s + 1);
+                let (tx, rx) = tokio_mpsc::channel(s + 1);
                 rt.block_on(plain_server(s, tx.clone()));
                 let start = Instant::now();
                 rt.block_on(plain_client(rx));
@@ -100,7 +99,7 @@ fn bench_send_recv(c: &mut Criterion) {
         b.iter_custom(|iters| {
             let mut total_duration = Duration::from_secs(0);
             for _ in 0..iters {
-                let (tx, rx) = mpsc::channel(s + 1);
+                let (tx, rx) = tokio_mpsc::channel(s + 1);
                 let start = Instant::now();
                 rt.block_on(plain_server(s, tx));
                 total_duration += start.elapsed();

--- a/dialectic/examples/hello.rs
+++ b/dialectic/examples/hello.rs
@@ -36,7 +36,7 @@ where
     let (greeting, chan) = chan.recv().await?;
     output.write_all(greeting.as_bytes()).await?;
     output.write_all(b"\n").await?;
-    chan.close();
+    chan.close().await?;
     Ok(())
 }
 
@@ -58,6 +58,6 @@ where
         name.chars().count()
     );
     let chan = chan.send(&greeting).await?;
-    chan.close();
+    chan.close().await?;
     Ok(())
 }

--- a/dialectic/examples/stack.rs
+++ b/dialectic/examples/stack.rs
@@ -83,7 +83,7 @@ where
                 let string = client_prompt(input, output, size).await?;
                 if string.is_empty() {
                     // Break this nested loop (about to go to pop/quit)
-                    break chan.choose::<0>().await?.close();
+                    break chan.choose::<0>().await?.close().await?;
                 } else {
                     // Push the string to the stack
                     let chan = chan.choose::<1>().await?.send(&string).await?;
@@ -126,7 +126,7 @@ where
         loop {
             chan = offer!(in chan {
                 // Client doesn't want to push a value
-                0 => break chan.close(),
+                0 => break chan.close().await?,
                 // Client wants to push a value
                 1 => {
                     let (string, chan) = chan.recv().await?;        // Receive pushed value

--- a/dialectic/examples/tally.rs
+++ b/dialectic/examples/tally.rs
@@ -66,7 +66,8 @@ where
             break chan.choose::<1>().await?;
         }
     }
-    .close();
+    .close()
+    .await?;
     Ok(())
 }
 
@@ -127,7 +128,7 @@ where
             }
         }
     };
-    chan.close();
+    chan.close().await?;
     Ok(done)
 }
 
@@ -150,7 +151,7 @@ where
                 chan.call(|chan| server_tally(&op, chan)).await?.1.unwrap()
             },
             // Client wants to quit
-            1 => break chan.close(),
+            1 => break chan.close().await?,
         })?;
     }
     Ok(())
@@ -181,7 +182,7 @@ where
             },
             // Client wants to finish this tally
             1 => {
-                chan.send(&tally).await?.close();
+                chan.send(&tally).await?.close().await?;
                 break Ok(());
             }
         })?;

--- a/dialectic/examples/template.rs
+++ b/dialectic/examples/template.rs
@@ -29,7 +29,7 @@ where
     Rx::Error: Error + Send,
 {
     // Do something with the channel...
-    chan.close();
+    chan.close().await?;
     Ok(())
 }
 
@@ -47,6 +47,6 @@ where
     Rx::Error: Error + Send,
 {
     // Do something with the channel...
-    chan.close();
+    chan.close().await?;
     Ok(())
 }

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -127,18 +127,6 @@ pub trait Transmit<T>: Transmitter {
         T: By<'a, Self::Convention>;
 }
 
-impl<Tx: TransmitChoice + Unpin, const LENGTH: usize> Transmit<Choice<LENGTH>> for Tx {
-    fn start_send<'a>(
-        self: Pin<&mut Self>,
-        choice: <Choice<LENGTH> as By<'a, Self::Convention>>::Type,
-    ) -> Result<(), Self::Error>
-    where
-        Choice<LENGTH>: By<'a, Self::Convention>,
-    {
-        self.start_send_choice(<Choice<LENGTH> as By<'a, Self::Convention>>::copy(choice))
-    }
-}
-
 /// A backend transport used for receiving (i.e. the `Rx` parameter of [`Chan`](crate::Chan)) must
 /// implement [`Receiver`], which specifies what type of errors it might return. This is a
 /// super-trait of [`Receive`], which is what's actually needed to receive particular values over a
@@ -193,27 +181,20 @@ pub trait Receive<T>: Receiver {
     fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<T, Self::Error>>;
 }
 
-impl<Rx: ReceiveChoice + Unpin, const LENGTH: usize> Receive<Choice<LENGTH>> for Rx {
-    fn poll_recv(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Choice<LENGTH>, Self::Error>> {
-        self.poll_recv_choice(cx)
-    }
-}
-
 /// This module defines the future types returned from the methods of [`ReceiveExt`],
 /// [`TransmitterExt`], and [`TransmitExt`].
 pub mod futures {
     mod close;
     mod flush;
     mod receive;
+    mod receive_choice;
     mod send;
     mod send_choice;
 
     pub use close::Close;
     pub use flush::Flush;
     pub use receive::Receive;
+    pub(crate) use receive_choice::ReceiveChoice;
     pub use send::Send;
     pub(crate) use send_choice::SendChoice;
 }

--- a/dialectic/src/backend.rs
+++ b/dialectic/src/backend.rs
@@ -1,20 +1,33 @@
 //! The interface implemented by all transport backends for a [`Chan`](crate::Chan).
 //!
 //! A [`Chan<S, Tx, Rx>`](crate::Chan) is parameterized by its transmitting channel `Tx` and its
-//! receiving channel `Rx`. In order to use a `Chan` to run a session, these underlying channels
-//! must implement the traits [`Transmitter`] and [`Receiver`], as well as [`Transmit<T>`](Transmit)
-//! and [`Receive<T>`](Receive) for at least the types `T` used in those capacities in any given
-//! session.
+//! receiving channel `Rx`. In order for `Tx` and `Rx` to serve as a backend for a
+//! [`Chan`](crate::Chan), they must implement, for each `T` that is *sent* and each `S` which is
+//! *received*:
+//!
+//! - `Tx`: [`Transmitter`] + [`Transmit<T>`](Transmit), and the marker traits [`Send`] + [`Unpin`]
+//!   + `'static`
+//! - `Rx`: [`Receiver`] + [`Receive<S>`](Receive), and the marker traits [`Send`] + [`Unpin`] +
+//!   `'static`
 //!
 //! Functions which are generic over their backend will in turn need to specify the bounds
 //! [`Transmit<T>`](Transmit) and [`Receive<T>`](Receive) for all `T`s they send and receive,
 //! respectively. The [`Transmitter`](macro@crate::Transmitter) and
 //! [`Receiver`](macro@crate::Receiver) attribute macros make this bound specification succinct; see
 //! their documentation for more details.
+//!
+//! The extension traits [`ReceiveExt`], [`TransmitterExt`], and [`TransmitExt`] provide a
+//! [`recv`](ReceiveExt::recv) asynchronous method for all receivers, and
+//! [`send`](TransmitExt::send), [`flush`](TransmitterExt::flush), and
+//! [`close`](TransmitterExt::close) asynchronous methods for all transmitters. As the implementor
+//! of a backend, you do not need to implement them yourself.
 
 #[doc(no_inline)]
 pub use call_by::{By, Convention, Mut, Ref, Val};
-use std::{future::Future, pin::Pin};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 mod choice;
 pub use choice::*;
@@ -38,15 +51,52 @@ pub trait Transmitter {
     /// convention, but is supported.
     type Convention: Convention;
 
-    /// Send any `Choice<N>` using the [`Convention`] specified by the trait implementation.
-    fn send_choice<'async_lifetime, const LENGTH: usize>(
-        &'async_lifetime mut self,
+    /// Attempts to prepare the transmitter to send a value.
+    ///
+    /// This method must be called and return `Poll::Ready(Ok(()))` prior to each call to
+    /// [`Transmitter::start_send_choice`] or [`Transmit::start_send`].
+    ///
+    /// This method returns `Poll::Ready` once the underlying transmitter is ready to initiate a
+    /// send operation. If this method returns `Poll::Pending`, the current task is registered to be
+    /// notified (via `cx.wake().wake_by_ref()`) when [`poll_ready`](Transmitter::poll_ready) should
+    /// be called again.
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+
+    /// Flush any remaining output from this transmitter.
+    ///
+    /// This method returns `Poll::Ready(Ok(()))` when nothing is left to be sent. If this value is
+    /// returned then it is guaranteed that all previous values sent via
+    /// [`Transmitter::start_send_choice`] or [`Transmit::start_send`] have been flushed, i.e. the
+    /// connection is "up to date". If this method returns `Poll::Pending`, there is more work left
+    /// to do, in which case the current task is registered to be notified (via
+    /// `cx.wake().wake_by_ref()`) when [`poll_ready`](Transmitter::poll_ready) should be called
+    /// again.
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+
+    /// Flush any remaining output from this transmitter and attempt to close it.
+    ///
+    /// This method returns `Poll::Ready(Ok(()))` when nothing is left to be sent. If this value is
+    /// returned then it is guaranteed that all previous values sent via
+    /// [`Transmitter::start_send_choice`] or [`Transmit::start_send`] have been flushed, i.e. the
+    /// connection is "up to date", and closed. If this method returns `Poll::Pending`, there is
+    /// more work left to do, in which case the current task is registered to be notified (via
+    /// `cx.wake().wake_by_ref()`) when [`poll_ready`](Transmitter::poll_ready) should be called
+    /// again.
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+
+    /// Begin the process of sending any [`Choice<N>`](Choice). Each call to this function must be
+    /// preceded by a successful call to [`Transmitter::poll_ready`] which returned
+    /// `Poll::Ready(Ok(()))`.
+    fn start_send_choice<const LENGTH: usize>(
+        self: Pin<&mut Self>,
         choice: Choice<LENGTH>,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>;
+    ) -> Result<(), Self::Error>;
 }
 
-/// If a transport is [`Transmit<T>`](Transmit), we can use it to [`send`](Transmit::send) a message
-/// of type `T` by [`Val`] or [`Ref`], depending on the calling convention specified by its
+/// If a transport is [`Transmit<T>`](Transmit), we can use it to [`send`](TransmitExt::send) a
+/// message of type `T` by [`Val`] or [`Ref`], depending on the calling convention specified by its
 /// [`Transmitter`] implementation.
 ///
 /// If you're writing a function and need a lot of different `Transmit<T>` bounds, the
@@ -64,14 +114,27 @@ pub trait Transmitter {
 /// [`dialectic_tokio_mpsc::Sender`]:
 /// https://docs.rs/dialectic-tokio-mpsc/latest/dialectic_tokio_mpsc/struct.Sender.html
 pub trait Transmit<T>: Transmitter {
-    /// Send a message using the [`Convention`] specified by the trait implementation.
-    fn send<'a, 'async_lifetime>(
-        &'async_lifetime mut self,
+    /// Begin the process of sending any `Choice<N>` using the [`Convention`] specified by the trait
+    /// implementation. Each call to this function must be preceded by a successful call to
+    /// [`Transmitter::poll_ready`] which returned `Poll::Ready(Ok(()))`.
+    fn start_send<'a>(
+        self: Pin<&mut Self>,
         message: <T as By<'a, Self::Convention>>::Type,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'async_lifetime>>
+    ) -> Result<(), Self::Error>
     where
-        T: By<'a, Self::Convention>,
-        'a: 'async_lifetime;
+        T: By<'a, Self::Convention>;
+}
+
+impl<Tx: Transmitter + Unpin, const LENGTH: usize> Transmit<Choice<LENGTH>> for Tx {
+    fn start_send<'a>(
+        self: Pin<&mut Self>,
+        choice: <Choice<LENGTH> as By<'a, Self::Convention>>::Type,
+    ) -> Result<(), Self::Error>
+    where
+        Choice<LENGTH>: By<'a, Self::Convention>,
+    {
+        self.start_send_choice(<Choice<LENGTH> as By<'a, Self::Convention>>::copy(choice))
+    }
 }
 
 /// A backend transport used for receiving (i.e. the `Rx` parameter of [`Chan`](crate::Chan)) must
@@ -85,15 +148,22 @@ pub trait Receiver {
     /// The type of possible errors when receiving.
     type Error;
 
-    /// Receive any `Choice<N>`. It is impossible to construct a `Choice<0>`, so if `N = 0`, a
-    /// [`Receiver::Error`] must be returned.
-    fn recv_choice<'async_lifetime, const LENGTH: usize>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Choice<LENGTH>, Self::Error>> + Send + 'async_lifetime>>;
+    /// Poll the receiver, attempting to receive a [`Choice<N>`](Choice).
+    ///
+    /// This method returns `Poll::Ready(Ok(choice))` when a `Choice<N>` has been received,
+    /// `Poll::Pending` if the underlying receiver is not yet ready to return a result, or
+    /// `Poll::Ready(Err(error))` if there was an error receiving the `Choice`.
+    ///
+    /// It is impossible to construct a `Choice<0>`, so if `N = 0`, a [`Receiver::Error`] must be
+    /// returned.
+    fn poll_recv_choice<const LENGTH: usize>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Choice<LENGTH>, Self::Error>>;
 }
 
-/// If a transport is [`Receive<T>`](Receive), we can use it to [`recv`](Receive::recv) a message of
-/// type `T`.
+/// If a transport is [`Receive<T>`](Receive), we can use it to [`recv`](ReceiveExt::recv) a message
+/// of type `T`.
 ///
 /// If you're writing a function and need a lot of different [`Receive<T>`](Receive) bounds, the
 /// [`Receiver`](macro@crate::Receiver) attribute macro can help you specify them more succinctly.
@@ -109,8 +179,95 @@ pub trait Receiver {
 /// [`dialectic_tokio_mpsc::Receiver`]:
 /// https://docs.rs/dialectic-tokio-mpsc/latest/dialectic_tokio_mpsc/struct.Receiver.html
 pub trait Receive<T>: Receiver {
-    /// Receive a message. This may require type annotations for disambiguation.
-    fn recv<'async_lifetime>(
-        &'async_lifetime mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<T, Self::Error>> + Send + 'async_lifetime>>;
+    /// Poll the receiver, attempting to receive a `T`.
+    ///
+    /// This method returns `Poll::Ready(Ok(t))` when a `T` has been received, `Poll::Pending` if
+    /// the underlying receiver is not yet ready to return a result, or `Poll::Ready(Err(error))` if
+    /// there was an error receiving the `T`.
+    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<T, Self::Error>>;
 }
+
+impl<Rx: Receiver + Unpin, const LENGTH: usize> Receive<Choice<LENGTH>> for Rx {
+    fn poll_recv(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Choice<LENGTH>, Self::Error>> {
+        self.poll_recv_choice(cx)
+    }
+}
+
+/// This module defines the future types returned from the methods of [`ReceiveExt`],
+/// [`TransmitterExt`], and [`TransmitExt`].
+pub mod futures {
+    mod close;
+    mod flush;
+    mod receive;
+    mod send;
+    mod send_choice;
+
+    pub use close::Close;
+    pub use flush::Flush;
+    pub use receive::Receive;
+    pub use send::Send;
+    pub(crate) use send_choice::SendChoice;
+}
+
+/// This extension trait is implemented for all [`Receive<T>`](Receive) transports, providing a
+/// convenient way to receive something on the receiver in asynchronous code.
+pub trait ReceiveExt<T>: Receive<T> {
+    /// Asynchronously receive something on this receiver.
+    ///
+    /// The returned [`Receive`](futures::Receive) struct implements [`Future<Output = Result<T,
+    /// Self::Error>>`](::futures::Future).
+    fn recv(&mut self) -> futures::Receive<Self, T> {
+        futures::Receive::new(self)
+    }
+}
+
+impl<Rx: Receive<T>, T> ReceiveExt<T> for Rx {}
+
+/// This extension trait is implemented for all [`Transmitter`]s, providing a convenient way to
+/// manipulate such a transmitter in asynchronous code.
+pub trait TransmitterExt: Transmitter {
+    /// Asynchronously flush this transmitter, ensuring that when the returned future completes, all
+    /// pending items to be sent have been transmitted in full.
+    ///
+    /// The returned [`Flush`](futures::Flush) struct implements [`Future<Output =
+    /// Result<(), Self::Error>>`](::futures::Future).
+    fn flush(&mut self) -> futures::Flush<Self> {
+        futures::Flush::new(self)
+    }
+
+    /// Asynchronously close this transmitter, ensuring that when the returned future completes, all
+    /// pending items to be sent have been transmitted in full, and the transmitter is closed.
+    ///
+    /// The returned [`Close`](futures::Close) struct implements [`Future<Output =
+    /// Result<(), Self::Error>>`](::futures::Future).
+    fn close(&mut self) -> futures::Close<Self> {
+        futures::Close::new(self)
+    }
+}
+
+impl<Tx: Transmitter> TransmitterExt for Tx {}
+
+/// This extension trait is implemented for all [`Transmit<T>`](Transmit), providing a convenient
+/// way to send values over a transmitter in asynchronous code.
+pub trait TransmitExt<T>: Transmit<T> {
+    /// Asynchronously send a `T` on this transmitter, by the [`Convention`] of that same
+    /// transmitter. This *does not* necessarily flush the transmitter; you *must* call
+    /// [`flush`](TransmitterExt::flush) to ensure that items are flushed.
+    ///
+    /// The returned [`SendChoice`](futures::SendChoice) struct implements [`Future<Output =
+    /// Result<(), Self::Error>>`](::futures::Future).
+    fn send<'a>(
+        &mut self,
+        message: <T as By<'a, Self::Convention>>::Type,
+    ) -> futures::Send<'_, 'a, Self, T>
+    where
+        T: By<'a, Self::Convention>,
+    {
+        futures::Send::new(self, message)
+    }
+}
+
+impl<Tx: Transmit<T> + Unpin, T> TransmitExt<T> for Tx {}

--- a/dialectic/src/backend/futures/close.rs
+++ b/dialectic/src/backend/futures/close.rs
@@ -1,0 +1,30 @@
+use crate::backend;
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// The future returned from [`TransmitterExt::close`](crate::backend::TransmitterExt::close).
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Close<'a, Tx: ?Sized> {
+    tx: &'a mut Tx,
+}
+
+impl<'a, Tx: ?Sized> Close<'a, Tx> {
+    pub(crate) fn new(tx: &'a mut Tx) -> Close<'a, Tx> {
+        Self { tx }
+    }
+}
+
+impl<Tx: Unpin + ?Sized> Unpin for Close<'_, Tx> {}
+
+impl<Tx: backend::Transmitter + Unpin + ?Sized> Future for Close<'_, Tx> {
+    type Output = Result<(), Tx::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        backend::Transmitter::poll_close(Pin::new(self.tx), cx)
+    }
+}

--- a/dialectic/src/backend/futures/flush.rs
+++ b/dialectic/src/backend/futures/flush.rs
@@ -1,0 +1,30 @@
+use crate::backend;
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// The future returned from [`TransmitterExt::flush`](crate::backend::TransmitterExt::flush).
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Flush<'a, Tx: ?Sized> {
+    tx: &'a mut Tx,
+}
+
+impl<'a, Tx: ?Sized> Flush<'a, Tx> {
+    pub(crate) fn new(tx: &'a mut Tx) -> Flush<'a, Tx> {
+        Self { tx }
+    }
+}
+
+impl<Tx: Unpin + ?Sized> Unpin for Flush<'_, Tx> {}
+
+impl<Tx: backend::Transmitter + Unpin + ?Sized> Future for Flush<'_, Tx> {
+    type Output = Result<(), Tx::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        backend::Transmitter::poll_flush(Pin::new(self.tx), cx)
+    }
+}

--- a/dialectic/src/backend/futures/receive.rs
+++ b/dialectic/src/backend/futures/receive.rs
@@ -1,0 +1,35 @@
+use crate::backend;
+use std::{
+    fmt::Debug,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// The future returned from [`ReceiveExt::recv`](crate::backend::ReceiveExt::recv).
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Receive<'a, Rx: ?Sized, T> {
+    rx: &'a mut Rx,
+    ty: PhantomData<fn() -> T>,
+}
+
+impl<'a, Rx: ?Sized, T> Receive<'a, Rx, T> {
+    pub(crate) fn new(rx: &'a mut Rx) -> Receive<'a, Rx, T> {
+        Self {
+            rx,
+            ty: PhantomData,
+        }
+    }
+}
+
+impl<Rx: Unpin + ?Sized, T> Unpin for Receive<'_, Rx, T> {}
+
+impl<T, Rx: backend::Receive<T> + Unpin + ?Sized> Future for Receive<'_, Rx, T> {
+    type Output = Result<T, Rx::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        backend::Receive::<T>::poll_recv(Pin::new(self.rx), cx)
+    }
+}

--- a/dialectic/src/backend/futures/receive_choice.rs
+++ b/dialectic/src/backend/futures/receive_choice.rs
@@ -1,0 +1,32 @@
+use crate::backend;
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// The future returned from [`ReceiveExt::recv`](crate::backend::ReceiveExt::recv).
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct ReceiveChoice<'a, Rx: ?Sized, const LENGTH: usize> {
+    rx: &'a mut Rx,
+}
+
+impl<'a, Rx: ?Sized, const LENGTH: usize> ReceiveChoice<'a, Rx, LENGTH> {
+    pub(crate) fn new(rx: &'a mut Rx) -> ReceiveChoice<'a, Rx, LENGTH> {
+        Self { rx }
+    }
+}
+
+impl<Rx: Unpin + ?Sized, const LENGTH: usize> Unpin for ReceiveChoice<'_, Rx, LENGTH> {}
+
+impl<Rx: backend::ReceiveChoice + Unpin + ?Sized, const LENGTH: usize> Future
+    for ReceiveChoice<'_, Rx, LENGTH>
+{
+    type Output = Result<backend::Choice<LENGTH>, Rx::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        backend::ReceiveChoice::poll_recv_choice(Pin::new(self.rx), cx)
+    }
+}

--- a/dialectic/src/backend/futures/send.rs
+++ b/dialectic/src/backend/futures/send.rs
@@ -1,0 +1,70 @@
+use crate::backend::{self, By};
+use futures::ready;
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// The future returned from [`TransmitExt::send`](crate::backend::TransmitExt::send).
+#[derive(derivative::Derivative)]
+#[derivative(Debug(bound = "Tx: Debug, <T as By<'b, Tx::Convention>>::Type: Debug"))]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Send<'a, 'b: 'a, Tx: ?Sized, T>
+where
+    Tx: backend::Transmit<T>,
+    T: By<'b, Tx::Convention>,
+{
+    tx: &'a mut Tx,
+    message: Option<<T as By<'b, Tx::Convention>>::Type>,
+}
+
+impl<'a, 'b: 'a, Tx, T> Unpin for Send<'a, 'b, Tx, T>
+where
+    Tx: backend::Transmit<T> + Unpin + ?Sized,
+    T: By<'b, Tx::Convention>,
+{
+}
+
+impl<'a, 'b, Tx, T> Send<'a, 'b, Tx, T>
+where
+    Tx: backend::Transmit<T> + ?Sized,
+    T: By<'b, Tx::Convention>,
+{
+    pub(crate) fn new(
+        tx: &'a mut Tx,
+        message: <T as By<'b, Tx::Convention>>::Type,
+    ) -> Send<'a, 'b, Tx, T> {
+        Self {
+            tx,
+            message: Some(message),
+        }
+    }
+}
+
+impl<'a, 'b, Tx, T> Send<'a, 'b, Tx, T>
+where
+    Tx: backend::Transmit<T> + Unpin + ?Sized,
+    T: By<'b, Tx::Convention>,
+{
+    pub(crate) fn tx_pin_mut(&mut self) -> Pin<&mut Tx> {
+        Pin::new(self.tx)
+    }
+}
+
+impl<'a, 'b: 'a, T, Tx> Future for Send<'a, 'b, Tx, T>
+where
+    Tx: backend::Transmit<T> + Unpin + ?Sized,
+    T: By<'b, Tx::Convention>,
+{
+    type Output = Result<(), Tx::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        ready!(this.tx_pin_mut().as_mut().poll_ready(cx))?;
+        let message = this.message.take().expect("polled `Send` after completion");
+        this.tx_pin_mut().start_send(message)?;
+        Poll::Ready(Ok(()))
+    }
+}

--- a/dialectic/src/backend/futures/send_choice.rs
+++ b/dialectic/src/backend/futures/send_choice.rs
@@ -1,0 +1,51 @@
+use crate::backend::{self, Choice};
+use futures::ready;
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// A future that sends a single [`Choice`] over `Tx` (internal implementation detail).
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct SendChoice<'a, Tx: ?Sized, const LENGTH: usize> {
+    tx: &'a mut Tx,
+    choice: Option<Choice<LENGTH>>,
+}
+
+impl<'a, Tx: ?Sized, const LENGTH: usize> Unpin for SendChoice<'a, Tx, LENGTH> {}
+
+impl<'a, Tx: ?Sized, const LENGTH: usize> SendChoice<'a, Tx, LENGTH> {
+    pub(crate) fn new(tx: &'a mut Tx, choice: Choice<LENGTH>) -> SendChoice<'a, Tx, LENGTH> {
+        Self {
+            tx,
+            choice: Some(choice),
+        }
+    }
+}
+
+impl<'a, Tx: Unpin + ?Sized, const LENGTH: usize> SendChoice<'a, Tx, LENGTH> {
+    pub(crate) fn tx_pin_mut(&mut self) -> Pin<&mut Tx> {
+        Pin::new(self.tx)
+    }
+}
+
+impl<'a, Tx, const LENGTH: usize> Future for SendChoice<'a, Tx, LENGTH>
+where
+    Tx: backend::Transmitter + Unpin + ?Sized,
+{
+    type Output = Result<(), Tx::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        ready!(this.tx_pin_mut().as_mut().poll_ready(cx))?;
+        let choice = this
+            .choice
+            .take()
+            .expect("polled `SendChoice` after completion");
+        this.tx_pin_mut().start_send_choice(choice)?;
+        Poll::Ready(Ok(()))
+    }
+}

--- a/dialectic/src/backend/futures/send_choice.rs
+++ b/dialectic/src/backend/futures/send_choice.rs
@@ -34,7 +34,7 @@ impl<'a, Tx: Unpin + ?Sized, const LENGTH: usize> SendChoice<'a, Tx, LENGTH> {
 
 impl<'a, Tx, const LENGTH: usize> Future for SendChoice<'a, Tx, LENGTH>
 where
-    Tx: backend::Transmitter + Unpin + ?Sized,
+    Tx: backend::TransmitChoice + Unpin + ?Sized,
 {
     type Output = Result<(), Tx::Error>;
 

--- a/dialectic/src/chan.rs
+++ b/dialectic/src/chan.rs
@@ -454,7 +454,10 @@ where
     pub async fn offer(mut self) -> Result<Branches<Choices, Tx, Rx>, Error<Tx, Rx>> {
         self.flush().await?;
         let (buffering_mode, tx, mut rx, drop_tx, drop_rx) = self.unwrap_contents();
-        let choice: Choice<LENGTH> = rx.as_mut().unwrap().recv().await.map_err(Error::Recv)?;
+        let choice: Choice<LENGTH> =
+            crate::backend::futures::ReceiveChoice::new(rx.as_mut().unwrap())
+                .await
+                .map_err(Error::Recv)?;
         let variant = choice.into();
         Ok(Branches {
             buffering_mode,

--- a/dialectic/src/chan.rs
+++ b/dialectic/src/chan.rs
@@ -6,7 +6,7 @@ use pin_project::pin_project;
 use std::{
     any::TypeId,
     convert::{TryFrom, TryInto},
-    fmt::{self, Debug, Display, Formatter},
+    fmt::Debug,
     marker::{self, PhantomData},
     mem,
     pin::Pin,
@@ -14,10 +14,14 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::tuple::{HasLength, List, Tuple};
-use crate::Unavailable;
-use crate::{backend::*, IncompleteHalf, SessionIncomplete};
-use crate::{prelude::*, types::*, unary::*};
+use crate::{
+    backend::*,
+    prelude::*,
+    tuple::{HasLength, List, Tuple},
+    types::*,
+    unary::*,
+    Error, IncompleteHalf, SessionIncomplete, Unavailable,
+};
 
 /// The buffering mode for a [`Chan`].
 ///
@@ -33,33 +37,6 @@ pub enum Buffering {
     /// Do not use buffering, regardless of whether the underlying backend supports it: follow every
     /// sending operation with an implicit call to [`flush`](Chan::flush).
     NoBuffering,
-}
-
-#[derive(Derivative, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[derivative(Debug(bound = "Tx::Error: Debug, Rx::Error: Debug"))]
-pub enum Error<Tx: Transmitter, Rx: Receiver> {
-    Send(Tx::Error),
-    Recv(Rx::Error),
-}
-
-impl<Tx: Transmitter, Rx: Receiver> Display for Error<Tx, Rx>
-where
-    Tx::Error: Display,
-    Rx::Error: Display,
-{
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Error::Send(e) => write!(f, "error while sending: {}", e),
-            Error::Recv(e) => write!(f, "error while receiving: {}", e),
-        }
-    }
-}
-
-impl<Tx: Transmitter, Rx: Receiver> std::error::Error for Error<Tx, Rx>
-where
-    Tx::Error: Debug + Display,
-    Rx::Error: Debug + Display,
-{
 }
 
 /// A bidirectional communications channel using the session type `P` over the connections `Tx` and

--- a/dialectic/src/error.rs
+++ b/dialectic/src/error.rs
@@ -1,3 +1,10 @@
+use std::{
+    convert::Infallible,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::backend::Transmitter;
 #[allow(unused_imports)] // To link with documentation
 use crate::prelude::*;
 
@@ -6,9 +13,34 @@ use crate::prelude::*;
 /// When using [`split`](Chan::split), the resultant two channels can only send or only receive,
 /// respectively. This is reflected at the type level by the presence of [`Unavailable`] on the type
 /// of the connection which *is not* present for each part of the split.
+///
+/// [`Unavailable`] *does* implement [`Transmitter`] and [`Receiver`] (which is necessary so that it
+/// can be a backend type in a [`Chan`]), but it *does not* implement [`ReceiveChoice`],
+/// [`TransmitChoice`], [`Receive`], or [`Transmit`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Unavailable {
     _priv: (),
+}
+
+impl Transmitter for Unavailable {
+    type Error = Infallible;
+    type Convention = Val;
+
+    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Receiver for Unavailable {
+    type Error = Infallible;
 }
 
 /// The error returned when a closure which is expected to complete a channel's session fails to

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -113,7 +113,6 @@ Once you've got a channel, here's what you can do:
 
 #[macro_use]
 extern crate derivative;
-use futures::Future;
 
 pub mod backend;
 pub mod tuple;

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -124,9 +124,9 @@ mod chan;
 mod error;
 mod session;
 
-pub use chan::{Branches, Chan};
+pub use chan::{Branches, Buffering, Chan};
 pub use dialectic_macro::{offer, Receiver, Session, Transmitter};
-pub use error::{IncompleteHalf, SessionIncomplete, Unavailable};
+pub use error::{Error, IncompleteHalf, SessionIncomplete, Unavailable};
 pub use session::Session;
 
 #[allow(unused_imports)] // If no backends are feature-enabled, don't warn
@@ -151,7 +151,9 @@ pub(crate) mod dialectic {
 /// all the bits and pieces you need to start writing programs with Dialectic.
 pub mod prelude {
     #[doc(no_inline)]
-    pub use crate::backend::{Choice, Receive, Receiver, Transmit, Transmitter};
+    pub use crate::backend::{
+        Choice, Receive, ReceiveChoice, Receiver, Transmit, TransmitChoice, Transmitter,
+    };
     #[doc(no_inline)]
     pub use crate::session::Session;
     #[doc(no_inline)]

--- a/dialectic/src/session.rs
+++ b/dialectic/src/session.rs
@@ -2,7 +2,7 @@ pub use crate::chan::Over;
 
 use super::*;
 use crate::types::*;
-use std::{future::Future, marker};
+use std::future::Future;
 
 /// The `Session` extension trait gives methods to create session-typed channels from session types.
 /// These are implemented as static methods on the session type itself.
@@ -104,8 +104,8 @@ where
     ) -> (Chan<Self, Tx, Rx>, Chan<Self::Dual, Tx, Rx>)
     where
         <Self as Session>::Dual: Scoped + Actionable + HasDual,
-        Tx: marker::Send + Unpin + 'static,
-        Rx: marker::Send + Unpin + 'static,
+        Tx: Transmitter,
+        Rx: Receiver,
     {
         let (tx0, rx0) = make();
         let (tx1, rx1) = make();
@@ -139,10 +139,10 @@ where
     ) -> (Chan<Self, Tx0, Rx1>, Chan<Self::Dual, Tx1, Rx0>)
     where
         <Self as Session>::Dual: Scoped + Actionable + HasDual,
-        Tx0: marker::Send + Unpin + 'static,
-        Rx0: marker::Send + Unpin + 'static,
-        Tx1: marker::Send + Unpin + 'static,
-        Rx1: marker::Send + Unpin + 'static,
+        Tx0: Transmitter,
+        Rx0: Receiver,
+        Tx1: Transmitter,
+        Rx1: Receiver,
     {
         let (tx0, rx0) = make0();
         let (tx1, rx1) = make1();
@@ -170,8 +170,8 @@ where
     /// ```
     fn wrap<Tx, Rx>(tx: Tx, rx: Rx) -> Chan<Self, Tx, Rx>
     where
-        Tx: marker::Send + Unpin + 'static,
-        Rx: marker::Send + Unpin + 'static,
+        Tx: Transmitter,
+        Rx: Receiver,
     {
         chan::Chan::from_raw_unchecked(tx, rx)
     }
@@ -261,8 +261,8 @@ where
     /// ```
     fn over<Tx, Rx, T, Err, F, Fut>(tx: Tx, rx: Rx, with_chan: F) -> Over<Tx, Rx, T, Err, Fut>
     where
-        Tx: std::marker::Send + Unpin + 'static,
-        Rx: std::marker::Send + Unpin + 'static,
+        Tx: Transmitter,
+        Rx: Receiver,
         F: FnOnce(Chan<Self, Tx, Rx>) -> Fut,
         Fut: Future<Output = Result<T, Err>>,
     {


### PR DESCRIPTION
This resolves #78 and along the way resolves #76.

- [ ] In order for this to work, a new point release of `call-by` needs to happen.