### PR TITLE
Tweaks to keep from poll fn refactor

### DIFF
--- a/dialectic-tokio-mpsc/Cargo.toml
+++ b/dialectic-tokio-mpsc/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/boltlabs-inc/dialectic"
 [dependencies]
 dialectic = { version = "0.4", path = "../dialectic" }
 thiserror = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["sync"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/dialectic/src/lib.rs
+++ b/dialectic/src/lib.rs
@@ -113,7 +113,6 @@ Once you've got a channel, here's what you can do:
 
 #[macro_use]
 extern crate derivative;
-use futures::Future;
 
 pub mod backend;
 pub mod tuple;

--- a/dialectic/src/session.rs
+++ b/dialectic/src/session.rs
@@ -1,8 +1,8 @@
 pub use crate::chan::Over;
 
-use super::*;
-use crate::types::*;
-use std::marker;
+use crate::types::{Actionable, HasDual, Scoped};
+use crate::Chan;
+use std::future::Future;
 
 /// The `Session` extension trait gives methods to create session-typed channels from session types.
 /// These are implemented as static methods on the session type itself.
@@ -100,12 +100,17 @@ where
     /// # }
     /// ```
     fn channel<Tx, Rx>(
-        make: impl FnMut() -> (Tx, Rx),
+        mut make: impl FnMut() -> (Tx, Rx),
     ) -> (Chan<Self, Tx, Rx>, Chan<Self::Dual, Tx, Rx>)
     where
         <Self as Session>::Dual: Scoped + Actionable + HasDual,
-        Tx: marker::Send + 'static,
-        Rx: marker::Send + 'static;
+        Tx: Send + 'static,
+        Rx: Send + 'static,
+    {
+        let (tx0, rx0) = make();
+        let (tx1, rx1) = make();
+        (Self::wrap(tx0, rx1), <Self::Dual>::wrap(tx1, rx0))
+    }
 
     /// Given two closures, each of which generates a uni-directional underlying transport channel,
     /// create a pair of dual [`Chan`]s which communicate over the transport channels resulting from
@@ -134,10 +139,15 @@ where
     ) -> (Chan<Self, Tx0, Rx1>, Chan<Self::Dual, Tx1, Rx0>)
     where
         <Self as Session>::Dual: Scoped + Actionable + HasDual,
-        Tx0: marker::Send + 'static,
-        Rx0: marker::Send + 'static,
-        Tx1: marker::Send + 'static,
-        Rx1: marker::Send + 'static;
+        Tx0: Send + 'static,
+        Rx0: Send + 'static,
+        Tx1: Send + 'static,
+        Rx1: Send + 'static,
+    {
+        let (tx0, rx0) = make0();
+        let (tx1, rx1) = make1();
+        (Self::wrap(tx0, rx1), <Self::Dual>::wrap(tx1, rx0))
+    }
 
     /// Given a transmitting and receiving end of an un-session-typed connection, wrap them in a new
     /// session-typed channel for the protocol `P.`
@@ -160,8 +170,11 @@ where
     /// ```
     fn wrap<Tx, Rx>(tx: Tx, rx: Rx) -> Chan<Self, Tx, Rx>
     where
-        Tx: marker::Send + 'static,
-        Rx: marker::Send + 'static;
+        Tx: Send + 'static,
+        Rx: Send + 'static,
+    {
+        Chan::from_raw_unchecked(tx, rx)
+    }
 
     /// Given a closure which runs the session on a channel from start to completion, run that
     /// session on the given pair of sending and receiving connections.
@@ -248,63 +261,16 @@ where
     /// ```
     fn over<Tx, Rx, T, Err, F, Fut>(tx: Tx, rx: Rx, with_chan: F) -> Over<Tx, Rx, T, Err, Fut>
     where
-        Tx: std::marker::Send + 'static,
-        Rx: std::marker::Send + 'static,
-        F: FnOnce(Chan<Self, Tx, Rx>) -> Fut,
-        Fut: Future<Output = Result<T, Err>>;
-}
-
-impl<P> Session for P
-where
-    Self: Scoped + Actionable + HasDual,
-{
-    type Dual = <Self as HasDual>::DualSession;
-    type Action = <Self as Actionable>::NextAction;
-
-    fn channel<Tx, Rx>(
-        mut make: impl FnMut() -> (Tx, Rx),
-    ) -> (Chan<Self, Tx, Rx>, Chan<Self::Dual, Tx, Rx>)
-    where
-        <Self as Session>::Dual: Scoped + Actionable + HasDual,
-        Tx: marker::Send + 'static,
-        Rx: marker::Send + 'static,
-    {
-        let (tx0, rx0) = make();
-        let (tx1, rx1) = make();
-        (P::wrap(tx0, rx1), <Self::Dual>::wrap(tx1, rx0))
-    }
-
-    fn bichannel<Tx0, Rx0, Tx1, Rx1>(
-        make0: impl FnOnce() -> (Tx0, Rx0),
-        make1: impl FnOnce() -> (Tx1, Rx1),
-    ) -> (Chan<Self, Tx0, Rx1>, Chan<Self::Dual, Tx1, Rx0>)
-    where
-        <Self as Session>::Dual: Scoped + Actionable + HasDual,
-        Tx0: marker::Send + 'static,
-        Rx0: marker::Send + 'static,
-        Tx1: marker::Send + 'static,
-        Rx1: marker::Send + 'static,
-    {
-        let (tx0, rx0) = make0();
-        let (tx1, rx1) = make1();
-        (P::wrap(tx0, rx1), <Self::Dual>::wrap(tx1, rx0))
-    }
-
-    fn wrap<Tx, Rx>(tx: Tx, rx: Rx) -> Chan<Self, Tx, Rx>
-    where
-        Tx: marker::Send + 'static,
-        Rx: marker::Send + 'static,
-    {
-        chan::Chan::from_raw_unchecked(tx, rx)
-    }
-
-    fn over<Tx, Rx, T, Err, F, Fut>(tx: Tx, rx: Rx, with_chan: F) -> Over<Tx, Rx, T, Err, Fut>
-    where
-        Tx: std::marker::Send + 'static,
-        Rx: std::marker::Send + 'static,
+        Tx: Send + 'static,
+        Rx: Send + 'static,
         F: FnOnce(Chan<Self, Tx, Rx>) -> Fut,
         Fut: Future<Output = Result<T, Err>>,
     {
         crate::chan::over::<Self, _, _, _, _, _, _>(tx, rx, with_chan)
     }
+}
+
+impl<S: Scoped + Actionable + HasDual> Session for S {
+    type Dual = <Self as HasDual>::DualSession;
+    type Action = <Self as Actionable>::NextAction;
 }

--- a/dialectic/src/session.rs
+++ b/dialectic/src/session.rs
@@ -59,6 +59,8 @@ use std::future::Future;
 ///    # use dialectic_tokio_mpsc as mpsc;
 ///    let (c1, c2) = <Session! { loop {} }>::channel(mpsc::unbounded_channel);
 ///    ```
+///
+/// [`Loop`]: crate::types::Loop
 pub trait Session
 where
     Self: Scoped
@@ -79,6 +81,16 @@ where
     /// iteration.
     ///
     /// This is always the action type defined by [`Actionable`] for this session type.
+    ///
+    /// [`Send`]: crate::types::Send
+    /// [`Recv`]: crate::types::Recv
+    /// [`Offer`]: crate::types::Offer
+    /// [`Choose`]: crate::types::Choose
+    /// [`Split`]: crate::types::Split
+    /// [`Call`]: crate::types::Call
+    /// [`Done`]: crate::types::Done
+    /// [`Loop`]: crate::types::Loop
+    /// [`Continue`]: crate::types::Continue
     type Action;
 
     /// Given a closure which generates a uni-directional underlying transport channel, create a
@@ -183,9 +195,9 @@ where
     ///
     /// The closure must *finish* the session `P` on the channel given to it and *drop* the finished
     /// channel before the future returns. If the channel is dropped before completing `P` or is not
-    /// dropped after completing `P`, a [`SessionIncomplete`] error will be returned instead of a
-    /// channel for `Q`. The best way to ensure this error does not occur is to call
-    /// [`close`](Chan::close) on the channel before returning from the future, because
+    /// dropped after completing `P`, a [`SessionIncomplete`](crate::SessionIncomplete) error will
+    /// be returned instead of a channel for `Q`. The best way to ensure this error does not occur
+    /// is to call [`close`](Chan::close) on the channel before returning from the future, because
     /// this statically checks that the session is complete and drops the channel.
     ///
     /// # Examples
@@ -242,7 +254,8 @@ where
     /// use dialectic::SessionIncomplete::BothHalves;
     /// use dialectic::IncompleteHalf::Unclosed;
     ///
-    /// // We'll put the `Chan` here so it outlives the closure. **Don't do this!**
+    /// // 🚨 DON'T DO THIS! 🚨
+    /// // We'll put the `Chan` here so it outlives the closure
     /// let hold_on_to_chan = Arc::new(Mutex::new(None));
     /// let hold = hold_on_to_chan.clone();
     ///
@@ -254,7 +267,8 @@ where
     ///
     /// assert!(matches!(ends, Err(BothHalves { tx: Unclosed, rx: Unclosed })));
     ///
-    /// // Make sure the `Chan` outlives the closure. **Don't do this!**
+    /// // 🚨 DON'T DO THIS! 🚨
+    /// // Make sure the `Chan` outlives the closure by holding onto it until here
     /// drop(hold_on_to_chan);
     /// # Ok(())
     /// # }


### PR DESCRIPTION
There were some tweaks that happened during the poll-fn refactor which actually should be propagated to `main`, even though we're putting the refactor itself on hold. These are those.