### PR TITLE
Add format check and caching to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,13 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         components: rustfmt, clippy
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Format check
       run: cargo fmt -- --check
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Run all doctests
       run: cargo test --all-features --doc --verbose
     - name: Build documentation
-      run: cargo doc --all-features --verbose
+      run: cargo doc --all-features --no-deps --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Format check
       run: cargo fmt -- --check
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,10 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        components: rustfmt, clippy
+
     - uses: actions/cache@v2
       with:
         path: |
@@ -26,6 +23,13 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        components: rustfmt, clippy
+        
     - name: Format check
       run: cargo fmt -- --check
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,8 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         components: rustfmt, clippy
+    - name: Format check
+      run: cargo fmt -- --check
     - name: Build
       run: cargo build --all-features --all-targets --verbose
     - name: Clippy lint


### PR DESCRIPTION
This will cause CI to fail immediately if a commit does not pass `cargo fmt -- --check`.

Additionally, it adds caching via the official GitHub caching action.