### PR TITLE
Make `Default` the only way to construct values of session types

### DIFF
--- a/dialectic/src/types.rs
+++ b/dialectic/src/types.rs
@@ -270,7 +270,7 @@ mod sealed {
     use super::*;
 
     /// Seal the [`Session`] trait so only types defined in this crate can be session types.
-    pub trait IsSession: Any {}
+    pub trait IsSession: Any + Default {}
 
     /// Seal the [`EachSession`] trait so it can't be extended in weird ways.
     pub trait EachSession {}

--- a/dialectic/src/types/call.rs
+++ b/dialectic/src/types/call.rs
@@ -1,11 +1,17 @@
-use std::any::Any;
+use std::{any::Any, marker::PhantomData};
 
 use super::sealed::IsSession;
 use super::*;
 
 /// Call the session `P` as a subroutine using [`call`](crate::Chan::call), then do the session `Q`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Call<P, Q>(pub P, pub Q);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Call<P, Q>(PhantomData<fn() -> P>, PhantomData<fn() -> Q>);
+
+impl<P, Q> Default for Call<P, Q> {
+    fn default() -> Self {
+        Call(PhantomData, PhantomData)
+    }
+}
 
 impl<P: Any, Q: Any> IsSession for Call<P, Q> {}
 
@@ -13,7 +19,7 @@ impl<P: HasDual, Q: HasDual> HasDual for Call<P, Q> {
     type DualSession = Call<P::DualSession, Q::DualSession>;
 }
 
-impl<P: 'static, Q: 'static> Actionable for Call<P, Q> {
+impl<P: Default + 'static, Q: Default + 'static> Actionable for Call<P, Q> {
     type NextAction = Self;
 }
 
@@ -23,7 +29,7 @@ impl<N: Unary, P: Subst<R, N>, Q: Subst<R, N>, R> Subst<R, N> for Call<P, Q> {
     type Substituted = Call<P::Substituted, Q::Substituted>;
 }
 
-impl<N: Unary, P: 'static, Q: Then<R, N>, R> Then<R, N> for Call<P, Q> {
+impl<N: Unary, P: Default + 'static, Q: Then<R, N>, R> Then<R, N> for Call<P, Q> {
     type Combined = Call<P, Q::Combined>;
 }
 

--- a/dialectic/src/types/call.rs
+++ b/dialectic/src/types/call.rs
@@ -19,7 +19,7 @@ impl<P: HasDual, Q: HasDual> HasDual for Call<P, Q> {
     type DualSession = Call<P::DualSession, Q::DualSession>;
 }
 
-impl<P: Default + 'static, Q: Default + 'static> Actionable for Call<P, Q> {
+impl<P: 'static, Q: 'static> Actionable for Call<P, Q> {
     type NextAction = Self;
 }
 
@@ -29,7 +29,7 @@ impl<N: Unary, P: Subst<R, N>, Q: Subst<R, N>, R> Subst<R, N> for Call<P, Q> {
     type Substituted = Call<P::Substituted, Q::Substituted>;
 }
 
-impl<N: Unary, P: Default + 'static, Q: Then<R, N>, R> Then<R, N> for Call<P, Q> {
+impl<N: Unary, P: 'static, Q: Then<R, N>, R> Then<R, N> for Call<P, Q> {
     type Combined = Call<P, Q::Combined>;
 }
 

--- a/dialectic/src/types/choose.rs
+++ b/dialectic/src/types/choose.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::{any::Any, marker::PhantomData};
 
 use super::sealed::IsSession;
 use super::*;
@@ -10,9 +10,14 @@ use crate::tuple::{List, Tuple};
 ///
 /// At most 128 choices can be presented to a `Choose` type; to choose from more options, nest
 /// `Choose`s within each other.
-#[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Choose<Choices>(pub Choices);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Choose<Choices>(PhantomData<fn() -> Choices>);
+
+impl<Choices> Default for Choose<Choices> {
+    fn default() -> Self {
+        Choose(PhantomData)
+    }
+}
 
 impl<Choices: Any> IsSession for Choose<Choices> {}
 

--- a/dialectic/src/types/continue.rs
+++ b/dialectic/src/types/continue.rs
@@ -5,7 +5,7 @@ use crate::unary::{self, Compare, Number, ToConstant, ToUnary};
 /// Repeat a [`Loop`]. The type-level index points to the loop to be repeated, counted from the
 /// innermost starting at `0`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Continue<const I: usize>;
+pub struct Continue<const I: usize>(());
 
 impl<const I: usize> IsSession for Continue<I> {}
 

--- a/dialectic/src/types/done.rs
+++ b/dialectic/src/types/done.rs
@@ -4,7 +4,7 @@ use super::*;
 /// A finished session. The only thing to do with a [`Chan`](crate::Chan) when it is `Done` is to
 /// drop it or, preferably, [`close`](crate::Chan::close) it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Done;
+pub struct Done(());
 
 impl IsSession for Done {}
 

--- a/dialectic/src/types/loop.rs
+++ b/dialectic/src/types/loop.rs
@@ -1,10 +1,17 @@
+use std::marker::PhantomData;
+
 use super::sealed::IsSession;
 use super::*;
 
 /// Label a loop point, which can be reiterated with [`Continue`].
-#[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Loop<P>(pub P);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Loop<P>(PhantomData<fn() -> P>);
+
+impl<P> Default for Loop<P> {
+    fn default() -> Self {
+        Loop(PhantomData)
+    }
+}
 
 impl<P: IsSession> IsSession for Loop<P> {}
 

--- a/dialectic/src/types/offer.rs
+++ b/dialectic/src/types/offer.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::{any::Any, marker::PhantomData};
 
 use super::sealed::IsSession;
 use super::*;
@@ -9,9 +9,14 @@ use crate::tuple::{List, Tuple};
 ///
 /// At most 128 choices can be offered in a single `Offer` type; to supply more options, nest
 /// `Offer`s within each other.
-#[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Offer<Choices>(pub Choices);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Offer<Choices>(PhantomData<fn() -> Choices>);
+
+impl<Choices> Default for Offer<Choices> {
+    fn default() -> Self {
+        Offer(PhantomData)
+    }
+}
 
 impl<Choices: Any> IsSession for Offer<Choices> {}
 

--- a/dialectic/src/types/recv.rs
+++ b/dialectic/src/types/recv.rs
@@ -4,9 +4,14 @@ use std::{any::Any, marker::PhantomData};
 
 /// Receive a message of type `T` using [`recv`](crate::Chan::recv), then continue with
 /// protocol `P`.
-#[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Recv<T, P>(pub PhantomData<T>, pub P);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Recv<T, P>(PhantomData<fn() -> T>, PhantomData<fn() -> P>);
+
+impl<T, P> Default for Recv<T, P> {
+    fn default() -> Self {
+        Recv(PhantomData, PhantomData)
+    }
+}
 
 impl<T: Any, P: Any> IsSession for Recv<T, P> {}
 

--- a/dialectic/src/types/send.rs
+++ b/dialectic/src/types/send.rs
@@ -4,9 +4,14 @@ use std::{any::Any, marker::PhantomData};
 
 /// Send a message of type `T` using [`send`](crate::Chan::send), then continue with
 /// protocol `P`.
-#[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Send<T, P>(pub PhantomData<T>, pub P);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Send<T, P>(PhantomData<fn() -> T>, PhantomData<fn() -> P>);
+
+impl<T, P> Default for Send<T, P> {
+    fn default() -> Self {
+        Send(PhantomData, PhantomData)
+    }
+}
 
 impl<T: Any, P: Any> IsSession for Send<T, P> {}
 

--- a/dialectic/src/types/split.rs
+++ b/dialectic/src/types/split.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::{any::Any, marker::PhantomData};
 
 use super::sealed::IsSession;
 use super::*;
@@ -8,8 +8,18 @@ use super::*;
 /// The type `Split<P, Q, R>` means: do the [`Transmit`](crate::backend::Transmit)-only session `P`
 /// concurrently with the [`Receive`](crate::backend::Receive)-only session `Q`, running them both
 /// to [`Done`], and when they've completed, do the session `R`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Split<P, Q, R>(pub P, pub Q, pub R);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Split<P, Q, R>(
+    PhantomData<fn() -> P>,
+    PhantomData<fn() -> Q>,
+    PhantomData<fn() -> R>,
+);
+
+impl<P, Q, R> Default for Split<P, Q, R> {
+    fn default() -> Self {
+        Split(PhantomData, PhantomData, PhantomData)
+    }
+}
 
 impl<P: Any, Q: Any, R: Any> IsSession for Split<P, Q, R> {}
 


### PR DESCRIPTION
Sometimes, it makes sense to pass around session types as zero-sized singleton values rather than supply them as type arguments. With this PR, all session types implement `Default`, which constructs them from their type. Additionally, it fixes their implementation to be "shallowly phantom" so that when they are materialized, there is not spurious drop glue, and prevents pattern-matching on them or creating them using the struct constructors.